### PR TITLE
ci(release): restore pypi environment for trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/molcrafts-molpy
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Add `environment: pypi` (and URL) to the release job. The PyPI Trusted Publisher on the `molcrafts-molpy` project is configured with environment `pypi`; without it the OIDC token claims do not match and publishing fails with `invalid-publisher`.

This was the root cause of the v0.3.1 publish failure ([run 24998295485](https://github.com/MolCrafts/molpy/actions/runs/24998295485)) — claims showed `environment: MISSING`.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the Release workflow via `workflow_dispatch` with version `v0.3.1`
- [ ] Verify `molcrafts-molpy 0.3.1` appears on PyPI