### PR TITLE
release/0.3.3: molrs backend + LAMMPS log reader + CG refactor

### DIFF
--- a/.claude/specs/INDEX.md
+++ b/.claude/specs/INDEX.md
@@ -1,0 +1,3 @@
+# Specs
+
+- [molrs-backend](molrs-backend.md) — molrs 作为 molpy 必选后端：Box 继承 + NeighborList/RDF + 替换 RDKit + 暴露 MSD/Cluster 等 [approved]

--- a/.claude/specs/molrs-backend.acceptance.md
+++ b/.claude/specs/molrs-backend.acceptance.md
@@ -1,0 +1,224 @@
+---
+slug: molrs-backend
+spec: molrs-backend.md
+created: 2026-05-06
+revised: 2026-05-06
+---
+
+# Acceptance — molrs-backend
+
+Binding "done" contract. `/mol:impl` must satisfy every criterion below
+before deleting the spec. Format follows
+`plugins/mol/docs/evaluator-protocol.md`.
+
+## Criteria
+
+```yaml
+# ── Phase 0 — molrs prerequisites ──────────────────────────────────
+
+- id: molrs-pybox-subclassable
+  type: code
+  summary: molrs.Box is Python-subclassable
+  pass_when: |
+    cd ../molrs && cargo build -p molrs-python --release
+    python -c "
+    import molrs
+    class Sub(molrs.Box): pass
+    Sub(__import__('numpy').eye(3) * 10.0)
+    "
+
+# ── Phase 1 — required dep + Box inheritance ───────────────────────
+
+- id: molrs-required-not-optional
+  type: code
+  summary: molcrafts-molrs is in [project.dependencies], not extras
+  pass_when: |
+    grep -E '^\s*"molcrafts-molrs' pyproject.toml             # in dependencies
+    ! grep -E '^\s*molrs\s*=\s*\[' pyproject.toml             # no extras key
+
+- id: molpy-box-is-a-molrs-box
+  type: code
+  summary: molpy.Box inherits from molrs.Box and behaves as one
+  pass_when: |
+    pytest tests/test_compute/test_box_inheritance.py::test_molpy_box_is_a_molrs_box -v
+    pytest tests/test_compute/test_box_inheritance.py::test_frame_box_passed_directly_to_molrs -v
+
+- id: molpy-box-public-api-preserved
+  type: code
+  summary: existing core/box.py public surface still resolves and existing tests pass
+  pass_when: |
+    pytest tests/test_core/test_box.py -v
+    python -c "
+    import molpy
+    b = molpy.Box.cubic(10.0)
+    assert b.style == molpy.Box.Style.ORTHOGONAL
+    assert b.matrix.shape == (3, 3)
+    "
+
+# ── Phase 2 — NeighborList + RDF ───────────────────────────────────
+
+- id: compute-neighborlist-class-exposed
+  type: code
+  summary: molpy.compute.NeighborList exists and is a Compute subclass
+  pass_when: |
+    python -c "from molpy.compute import NeighborList; \
+               from molpy.compute.base import Compute; \
+               assert issubclass(NeighborList, Compute)"
+
+- id: compute-rdf-class-exposed
+  type: code
+  summary: molpy.compute.RDF exists and is a Compute subclass
+  pass_when: |
+    python -c "from molpy.compute import RDF; \
+               from molpy.compute.base import Compute; \
+               assert issubclass(RDF, Compute)"
+
+- id: neighborlist-parity-with-molrs
+  type: numerical
+  summary: molpy.compute.NeighborList output matches direct molrs.NeighborQuery
+  pass_when: |
+    pytest tests/test_compute/test_neighborlist.py::test_parity_with_molrs_direct -v
+  tolerance:
+    pair_count: exact
+    distances: 1e-12 (absolute, after canonical sort)
+
+- id: rdf-ideal-gas-correct
+  type: numerical
+  summary: g(r) for uniform random points lies in [0.7, 1.3] across middle bins
+  pass_when: |
+    pytest tests/test_compute/test_rdf.py::test_ideal_gas_g_of_r_approaches_one -v
+  tolerance:
+    g_of_r_middle_bins: within 0.3 of 1.0 (n_points >= 2000, averaged over >= 5 frames)
+
+- id: input-frame-immutable
+  type: code
+  summary: NeighborList and RDF do not mutate the input frame
+  pass_when: |
+    pytest tests/test_compute/test_neighborlist.py::test_input_frame_immutable \
+           tests/test_compute/test_rdf.py::test_input_frame_immutable -v
+
+- id: rdf-requires-box
+  type: code
+  summary: RDF on a frame without a box raises ValueError mentioning "box"
+  pass_when: |
+    pytest tests/test_compute/test_rdf.py::test_no_box_raises -v
+
+# ── Phase 3 — RDKit replacement ────────────────────────────────────
+
+- id: rdkit-module-deleted
+  type: code
+  summary: compute/rdkit.py is removed, _HAS_RDKIT is gone, no rdkit extras
+  pass_when: |
+    test ! -e src/molpy/compute/rdkit.py
+    ! grep -rE '_HAS_RDKIT' src/molpy/
+    ! grep -E '^\s*rdkit\s*=\s*\[' pyproject.toml
+
+- id: embed-replacement-physical-sanity
+  type: numerical
+  summary: new molrs-backed Generate3D produces geometries with bond lengths within 10% of literature values for a small molecule set
+  pass_when: |
+    pytest tests/test_compute/test_embed_replacement.py -v
+  tolerance:
+    bond_length: ±10% vs literature for water, methane, ethanol
+
+# ── Phase 4 — MCD / PMSD internals ─────────────────────────────────
+
+- id: mcd-pmsd-public-signature-preserved
+  type: code
+  summary: MCDCompute and PMSDCompute keep their public signatures after internal rewiring
+  pass_when: |
+    pytest tests/test_compute/test_mcd.py tests/test_compute/test_pmsd.py -v
+    # Plus: existing call sites in tests/ and notebooks compile (`python -m compileall ...`).
+
+# ── Phase 5 — exposed molrs analyses ───────────────────────────────
+
+- id: exposed-analyses-importable
+  type: code
+  summary: every exposed molrs analysis is importable from molpy.compute
+  pass_when: |
+    python -c "
+    from molpy.compute import (
+        MSD, Cluster, ClusterCenters, CenterOfMass,
+        GyrationTensor, InertiaTensor, RadiusOfGyration,
+        Pca, KMeans,
+    )
+    "
+
+- id: exposed-analyses-parity
+  type: numerical
+  summary: each exposed analysis has a passing parity test vs direct molrs.<X>.compute
+  pass_when: |
+    pytest tests/test_compute/ -k "parity" -v
+  tolerance:
+    numeric_outputs: 1e-12 (absolute, post canonical sort) — except KMeans whose
+      output depends on RNG seed; assert seed-pinned reproducibility instead.
+
+# ── Cross-cutting hygiene ──────────────────────────────────────────
+
+- id: zero-extra-copy-discipline
+  type: code
+  summary: no defensive .copy() / copy=True anywhere in compute/
+  pass_when: |
+    ! grep -rE '\.copy\(\)|copy=True' src/molpy/compute/
+    # The single physical copy lives inside Block.__getitem__(list) (np.column_stack);
+    # outside that one site, the boundary is zero-copy.
+
+- id: no-molrs-gate-flag
+  type: code
+  summary: molrs is unconditional — no _HAS_MOLRS flag, no gated import
+  pass_when: |
+    ! grep -rE '_HAS_MOLRS' src/molpy/
+    ! grep -rE 'try:\s*\n\s+import molrs' src/molpy/
+
+- id: no-frame-to-xyz-helper
+  type: code
+  summary: there is no _frame_to_xyz / _frame_to_pybox helper anywhere
+  pass_when: |
+    ! grep -rE '_frame_to_xyz|_frame_to_pybox' src/molpy/
+
+- id: docs-page-published
+  type: docs
+  summary: user-guide page documents installation, Box inheritance, NeighborList + RDF, and the analysis catalog
+  pass_when: |
+    test -f docs/user/compute/molrs-backend.md
+    grep -q 'class Box(molrs.Box)' docs/user/compute/molrs-backend.md
+    grep -q 'NeighborList' docs/user/compute/molrs-backend.md
+    grep -q 'RDF' docs/user/compute/molrs-backend.md
+    grep -q 'MSD\|Cluster\|GyrationTensor' docs/user/compute/molrs-backend.md
+
+- id: changelog-breaking-change
+  type: docs
+  summary: changelog calls out that molrs is now required and rdkit extras are removed
+  pass_when: |
+    grep -i 'breaking' docs/changelog.md
+    grep -q 'molcrafts-molrs' docs/changelog.md
+    grep -q 'rdkit' docs/changelog.md
+
+- id: full-test-suite-green
+  type: code
+  summary: full molpy test suite (excluding external) is green
+  pass_when: |
+    pytest tests/ -m "not external" -q
+```
+
+## Notes for /mol:impl
+
+- **Phase 0 is a hard prerequisite.** Until the molrs `subclass`-flag patch
+  ships in a published `molcrafts-molrs` release, Phase 1's Box-inheritance
+  work cannot land. If the molrs patch is delayed, you may either (a) bump
+  the dependency to a path/git source temporarily, or (b) pause Phase 1
+  and proceed with Phases 2–5 using composition (and re-add the inheritance
+  patch later) — but flag the deviation in the spec before doing so.
+- **Phase 4 and Phase 5 tasks are intentionally left as one-line entries.**
+  Decompose each into per-operator subtasks at the start of those phases
+  rather than up front, so the breakdown reflects real signatures
+  encountered during implementation.
+- All `numerical` criteria are also covered by `code` test invocations —
+  no separate runtime evaluator is needed (no `ui_runtime` criteria here).
+- The `zero-extra-copy-discipline` and `no-frame-to-xyz-helper` criteria
+  are the encoded form of the user's directive: no Python-side adapter
+  layer, just direct calls into molrs.
+- `full-test-suite-green` is the final gate; run it last. It must pass
+  without the previously-existing `[molrs]` and `[rdkit]` extras (those
+  keys are gone), so don't try to re-add them as a workaround for
+  unrelated test failures.

--- a/.claude/specs/molrs-backend.md
+++ b/.claude/specs/molrs-backend.md
@@ -1,0 +1,297 @@
+---
+slug: molrs-backend
+status: in-progress
+created: 2026-05-06
+revised: 2026-05-06
+---
+
+# molrs-backend — molrs 作为 molpy 的默认计算后端
+
+## Summary
+
+将 molrs（Rust，PyPI 包 `molcrafts-molrs`，`import molrs`）作为
+**molpy 的必选运行时依赖**，并以「**继承优先 / 直接复用 molrs 类型**」
+的原则重构相关数据模型与 compute 算子：
+
+- **数据模型层** — molpy.Box 直接继承 molrs.Box；其它有 molrs 等价物
+  的容器（NeighborList、RDFResult 等）直接复用，不再做 wrapper。
+- **新算子** — `molpy.compute.NeighborList`、`molpy.compute.RDF`，
+  molpy 风格 API，molrs 后端。
+- **替换现有算子** — MCD / PMSD / RDKit 三块逐项审查，能映射到 molrs
+  的（RDKit 3D embed → molrs.embed）做替换；molrs 无等价（MCD/PMSD 时间
+  相关分析）的保留 Python 实现，但底层距离/邻居/PBC 走 molrs。
+- **拓宽分析覆盖** — 把 molrs 已有的 MSD / Cluster / GyrationTensor /
+  InertiaTensor / RadiusOfGyration / CenterOfMass / PCA / KMeans 通过
+  molpy 风格的 `Compute` 子类对外暴露。
+
+molrs 不再可选。这是一次有意识的破坏性变更（详见 Out of scope）。
+
+## Domain basis
+
+- **邻居列表**：链表/链格法 (cell list / linked-cell)，O(N)。已实现于
+  `molrs::neighbors::LinkCell` + `NeighborQuery`，PyO3 暴露为
+  `molrs.NeighborQuery` / `molrs.NeighborList`。
+- **RDF**：g(r) = (V / (N·N_q)) · ⟨n(r)⟩ / (4πr² Δr)。
+  Allen & Tildesley, *Computer Simulation of Liquids*, 2nd ed., §2.6。
+  已实现于 `molrs-compute::RDF`，`compute()` 内部即 `finalize()`。
+- **MSD / Cluster / Gyration / Inertia / Rg / COM / PCA / KMeans**：
+  均为标准轨迹分析；`molrs-compute` 已实现并通过 `molrs.MSD` / `Cluster`
+  / `GyrationTensor` 等导出。
+
+无新物理；molpy 侧只做 API 适配。
+
+## Design
+
+### 依赖关系
+
+```toml
+# pyproject.toml
+[project]
+dependencies = [
+    # ... existing ...
+    "molcrafts-molrs>=0.0.7",
+]
+```
+
+不再有 `[project.optional-dependencies].molrs`。这是 **breaking change**：
+下游用户必须升级。changelog 必须明确说明（见 docs 任务）。
+
+### 继承优先：molpy.Box ← molrs.Box
+
+```python
+# src/molpy/core/box.py
+import molrs
+import numpy as np
+
+class Box(molrs.Box):
+    """molpy 风格的 Box，直接继承 molrs.Box。"""
+
+    class Style(Enum):
+        FREE = 0
+        ORTHOGONAL = 1
+        TRICLINIC = 2
+
+    def __init__(self, matrix=None, pbc=None, origin=None):
+        h, pbc, origin = _normalize_box_args(matrix, pbc, origin)
+        super().__init__(h, origin=origin, pbc=pbc)
+        # Python-only state needed by molpy (PeriodicBoundary 接口、Style 枚举等)
+        # 通过组合 / 委托补足；core/box.py 现有 API 保留
+
+    @classmethod
+    def cubic(cls, length): ...
+    @classmethod
+    def from_lengths_angles(cls, lengths, angles): ...
+    @property
+    def style(self) -> "Box.Style": ...
+    # ...其它 molpy 已有方法
+```
+
+`PeriodicBoundary` 旧基类移除或改为 mixin（取决于其方法是否仍被引用，
+实现期审）。
+
+**前置条件**：molrs-python 侧 `#[pyclass(name = "Box", from_py_object)]`
+必须加 `subclass`。这是本 spec 显式纳入的 molrs 修改。
+
+### 直接复用：NeighborList / RDFResult
+
+不做 molpy 侧 wrapper。`molpy.compute.NeighborList`(算子) 内部返回
+`molrs.NeighborList`(结果) 原样：
+
+```python
+# src/molpy/compute/neighborlist.py
+import molrs
+from .base import Compute
+
+class NeighborList(Compute):
+    def __init__(self, cutoff: float):
+        self.cutoff = cutoff
+
+    def __call__(self, frame) -> molrs.NeighborList:
+        nq = molrs.NeighborQuery(frame.box, frame["atoms"][["x", "y", "z"]], self.cutoff)
+        return nq.query_self()
+```
+
+注意：
+- `frame.box` 已经 IS-A `molrs.Box`，无需转换。
+- `frame["atoms"][["x", "y", "z"]]` 通过 `Block.__getitem__(list)` 走
+  `np.column_stack` 路径，返回 (N, 3) ndarray。这就是**唯一一次**坐标
+  拷贝；没有任何额外的 `_frame_to_xyz` / `_molrs.py` 适配层。
+
+RDF 同理：
+
+```python
+# src/molpy/compute/rdf.py
+import molrs
+
+class RDF(Compute):
+    def __init__(self, n_bins, r_max, r_min=0.0):
+        self._inner = molrs.RDF(n_bins, r_max, r_min)
+
+    def __call__(self, frames, neighbors) -> molrs.RDFResult:
+        # frames / neighbors 都已是 molrs 友好类型；molpy 不再 wrap。
+        return self._inner.compute(frames, neighbors)
+```
+
+### 替换现有 compute 算子
+
+| 现有 molpy 算子 | molrs 等价 | 决策 |
+|---|---|---|
+| `Generate3D` (RDKit) | `molrs.generate_3d` + `EmbedOptions` | 替换 |
+| `OptimizeGeometry` (RDKit) | molrs.embed pipeline 的最终 minimize 阶段 | 替换 |
+| `MCDCompute` | 无 (molrs 只有 MSD) | 保留 Python 实现，底层距离/PBC 改走 molrs |
+| `PMSDCompute` | 无 | 同上 |
+
+### 暴露其它 molrs 分析
+
+为以下每一项添加一个 `molpy.compute.<Name>` 薄壳类（仅参数转发 + molpy
+风格 callable 接口）：
+
+`MSD`、`Cluster`、`ClusterCenters`、`CenterOfMass`、`GyrationTensor`、
+`InertiaTensor`、`RadiusOfGyration`、`Pca`、`KMeans`。
+
+每个 op 都是 5–15 行的 `Compute` 子类，结果直接返回 molrs 的
+`*Result` 类型，不另起 `molpy.*Result`。
+
+### 内存拷贝纪律
+
+所有边界一律走 PyO3 `PyReadonlyArray2` 零拷贝视图；返回的索引/距离由
+molrs 以 `borrow_from_array` 形式回传。整个 molpy 侧**禁止**调用 `.copy()`
+或 `.astype(..., copy=True)`，由验收契约里的 lint 强制（grep `compute/`
+目录）。
+
+唯一的物理拷贝是 `Block.__getitem__(["x","y","z"])` 内部的
+`np.column_stack`——这一次重排无法消除，除非把 frame 坐标存储改为
+单列 (N, 3)（出 scope）。
+
+### 不可变性
+
+所有 `Compute.__call__` 不修改输入 frame：不写回 atoms block，不挂
+属性，不缓存。返回值可以直接是 molrs 类型（其底层 buffer 由 molrs
+所有，但只读）。
+
+## Files
+
+| 文件 | 作用 |
+|---|---|
+| **molpy 侧** | |
+| `pyproject.toml` | `molcrafts-molrs` 移入主 `dependencies`；删 extras 项 |
+| `src/molpy/core/box.py` | `class Box(molrs.Box)`；保留 `Style`/`cubic`/`from_lengths_angles` 等 |
+| `src/molpy/core/region.py` | `PeriodicBoundary` 评估去留 |
+| `src/molpy/compute/neighborlist.py` | `NeighborList` 算子（薄壳） |
+| `src/molpy/compute/rdf.py` | `RDF` 算子（薄壳） |
+| `src/molpy/compute/msd.py` | `MSD` 算子 |
+| `src/molpy/compute/cluster.py` | `Cluster` + `ClusterCenters` |
+| `src/molpy/compute/shape.py` | `GyrationTensor` + `InertiaTensor` + `RadiusOfGyration` + `CenterOfMass` |
+| `src/molpy/compute/decomposition.py` | `Pca` + `KMeans` |
+| `src/molpy/compute/embed.py` | `Generate3D` + `OptimizeGeometry`，替换 `compute/rdkit.py` |
+| `src/molpy/compute/__init__.py` | 重新整理 `__all__`；删 `_HAS_RDKIT` / 不再有 `_HAS_MOLRS` |
+| `src/molpy/compute/rdkit.py` | **删除**（被 embed.py 取代） |
+| `src/molpy/compute/mcd.py` | 内部 PBC 距离改调 molrs；签名不变 |
+| `src/molpy/compute/pmsd.py` | 同上 |
+| `tests/test_compute/test_neighborlist.py` | 新算子单测 + parity + 不可变性 |
+| `tests/test_compute/test_rdf.py` | 理想气体 g(r)≈1 / 多帧累积 / 缺 box |
+| `tests/test_compute/test_box_inheritance.py` | `isinstance(molpy.Box(...), molrs.Box)`；frame.box 直传 molrs API |
+| `tests/test_compute/test_msd.py` etc. | 每个新暴露算子各一个 smoke + parity 测试 |
+| `tests/test_compute/test_embed_replacement.py` | 替换前后产物等价（构象 RMSD ≤ tol） |
+| `tests/test_core/test_box.py` | 现有 Box 测试需更新构造签名 |
+| `docs/user/compute/molrs-backend.md` | 安装、API 说明、与旧版差异 |
+| `docs/changelog.md` | breaking change 条目 |
+| **molrs 侧（本 spec 显式纳入）** | |
+| `molrs/molrs-python/src/simbox.rs` | `#[pyclass(...)]` 加 `subclass` 标记 |
+| `molrs/molrs-python/tests/test_subclass.py` | Python 端验证 `class Sub(molrs.Box)` 工作 |
+
+## Tasks
+
+> 共 5 个 Phase；每 Phase 内部 RED-before-GREEN。Phase 4/5 列为单行
+> 高层任务，`/mol:impl` 启动时再逐算子展开。
+
+**Phase 0 — molrs 前置**
+
+- [x] Patch `molrs/molrs-python/src/simbox.rs`: change `#[pyclass(name = "Box", from_py_object)]` to add `subclass`. Add `tests/test_subclass.py` confirming `class Sub(molrs.Box)` instantiates and inherits methods. Cut a new `molcrafts-molrs` patch release (e.g. 0.0.8).  *(release deferred until full suite green)*
+
+**Phase 1 — 必选依赖 + Box 继承**
+
+- [x] Move `molcrafts-molrs>=0.0.8` from optional-dependencies to main `dependencies` in `pyproject.toml`; remove the `molrs` extras key; verify `pip install -e ".[dev]"` resolves.
+- [x] Write failing test `test_box_inheritance.py::test_molpy_box_is_a_molrs_box` — `isinstance(molpy.Box.cubic(10.0), molrs.Box) is True`.
+- [x] Refactor `core/box.py` so `class Box(molrs.Box)`; preserve all public API (`Style`, `cubic`, `from_lengths_angles`, `matrix`, `origin`, `pbc`, `lengths`, `tilts`, `__mul__`, `__eq__`, `__repr__`); test passes.  *(setters and `set_*` mutators removed — Box is now immutable; updated 3 tests in `test_core/test_box.py` accordingly. Mutators were unused in production code.)*
+- [x] Update existing `test_core/test_box.py` for any signature changes; full `test_core/` suite green.
+- [x] Write failing test `test_box_inheritance.py::test_frame_box_passed_directly_to_molrs` — `molrs.NeighborQuery(frame.box, xyz, 2.0)` accepts `frame.box` with no conversion.
+
+**Phase 2 — NeighborList + RDF (新算子)**
+
+- [x] Write failing test `test_neighborlist.py::test_basic_periodic` — random frame + cubic box → `num_pairs > 0`, all distances ≤ cutoff.
+- [x] Implement `compute/neighborlist.py` (~10 lines: `Compute` subclass forwarding to `molrs.NeighborQuery`); test passes.
+- [x] Write failing test `test_neighborlist.py::test_parity_with_molrs_direct` — same inputs through `molrs.NeighborQuery` directly; assert pair count + distance set match within 1e-12.
+- [x] Write failing test `test_neighborlist.py::test_input_frame_immutable` — snapshot `frame.box.matrix` and `frame["atoms"]["x"/"y"/"z"]`; unchanged after `__call__`.
+- [x] Write failing test `test_rdf.py::test_ideal_gas_g_of_r_approaches_one` — uniform random points, middle bins ∈ [0.7, 1.3].
+- [x] Implement `compute/rdf.py` (~25 lines including the molrs.Frame view adapter); test passes.  *(The view adapter creates a fresh molrs.Frame whose simbox = molpy.Frame.box — zero coordinate copy because RDF reads coordinates from the NeighborList, not the frame itself.)*
+- [x] Write failing test `test_rdf.py::test_multi_frame_aggregation` — list of 3 frames vs single-frame averaged manually; assert agreement.
+- [x] Write failing test `test_rdf.py::test_no_box_raises` — frame without `.box` → `ValueError` mentioning "box".
+
+**Phase 3 — 替换 RDKit-based embed**
+
+- [ ] Write failing test `test_embed_replacement.py::test_generate3d_returns_3d_coords` against the new `compute/embed.py::Generate3D` (molrs-backed).
+- [ ] Implement `compute/embed.py::Generate3D` and `OptimizeGeometry` wrapping `molrs.generate_3d` / `molrs.EmbedOptions`; tests pass.
+- [ ] Write parity test `test_embed_replacement.py::test_old_vs_new_geometry_close` — for a small molecule set, RMSD between old RDKit-produced and new molrs-produced geometries within a documented tolerance (or, if not bit-comparable, both pass an independent geometry sanity check: bond lengths within 10% of literature values).
+- [ ] Delete `src/molpy/compute/rdkit.py`; remove `_HAS_RDKIT` from `compute/__init__.py`; remove `rdkit` extras from pyproject.
+- [ ] Update any docs / examples that referenced the old RDKit-backed names.
+
+**Phase 4 — MCD / PMSD 内部改造**
+
+> 单行高层任务；每条在 `/mol:impl` 启动时拆为 (a) 改 PBC 距离调用 →
+> molrs.NeighborQuery (b) parity 测试 vs 旧实现 (c) 性能基准（可选）。
+
+- [ ] 把 `compute/mcd.py` 内部的 PBC 距离/邻居计算改调 molrs；公开签名保持不变。
+- [ ] 把 `compute/pmsd.py` 内部的 PBC 距离/邻居计算改调 molrs；公开签名保持不变。
+
+**Phase 5 — 暴露其它 molrs 分析**
+
+> 单行高层任务；`/mol:impl` 启动时为每个 op 拆为 (a) 失败测试
+> (b) `Compute` 子类实现 (c) 与 `molrs.<X>.compute(...)` 的 parity 测试
+> (d) 文档段落。
+
+- [ ] 暴露 `molrs.MSD` 为 `molpy.compute.MSD`。
+- [ ] 暴露 `molrs.Cluster` + `molrs.ClusterCenters` 为 `molpy.compute.Cluster` / `ClusterCenters`。
+- [ ] 暴露 `molrs.CenterOfMass` 为 `molpy.compute.CenterOfMass`。
+- [ ] 暴露 `molrs.GyrationTensor` / `InertiaTensor` / `RadiusOfGyration` 为对应 molpy 算子。
+- [ ] 暴露 `molrs.Pca2` 为 `molpy.compute.Pca`；暴露 `molrs.KMeans` 为 `molpy.compute.KMeans`。
+
+**Phase 6 — 文档与收尾**
+
+- [ ] 写 `docs/user/compute/molrs-backend.md`：安装命令、Box 继承示例、NeighborList + RDF 最小例子、性能说明（一处 column_stack 拷贝及其原因）、其它分析的清单与示例。
+- [ ] 写 `docs/changelog.md` 的 breaking-change 段：molrs 由可选变必选；`compute.rdkit` 模块移除；最小 Python 兼容版本（如有变化）。
+- [ ] Run `pytest tests/ -v -m "not external"` 与 `pre-commit run --all-files`；都绿。
+
+## Testing strategy
+
+- **Unit** — 每个新算子：实例化、属性、错误路径。
+- **Parity** — 每个 wrapper 算子 (`NeighborList`/`RDF`/MSD/Cluster/...) 都
+  必须有一个 `test_parity_with_molrs_direct`：绕过 molpy 包装，直接调
+  `molrs.<X>`，assert 输出按 canonical 排序后逐元素一致或在 1e-12 之内。
+  Box 继承额外加 `isinstance(molpy.Box(...), molrs.Box)` 一行 assert。
+- **Scientific** — RDF 理想气体 g(r)≈1 是物理 sanity 检验；其它分析依赖
+  parity 测试间接保证（molrs 自身已有物理测试）。
+- **Immutability** — 每个新算子 `test_input_frame_immutable`。
+- **回归** — 替换 RDKit embed 必须 parity 到旧实现的物理量（键长 /
+  RMSD），不能凭"两边都跑通"就算过。
+- **现有套件兼容** — `test_core/`、`test_io/` 等模块不应受 Box 继承影响；
+  若有失败，必须修而非 skip。
+- **删除验证** — `compute/rdkit.py` 删除后 `pytest -k rdkit` 没有任何
+  剩余测试；`grep -r '_HAS_RDKIT\|_HAS_MOLRS' src/` 无命中。
+
+`pytest tests/test_compute/ --cov=src/molpy/compute -v` ≥ 80%。
+
+## Out of scope
+
+- 多组分 / 类型间 RDF（g_AB(r)）—— v1 只支持单一物种 self-pair，留作
+  follow-up spec。
+- 把 frame 坐标存储改为单列 (N, 3) ndarray —— 这能消除最后一个
+  column_stack 拷贝，但需要独立的 `frame-storage-refactor` spec
+  覆盖 Block / Frame / 所有 IO reader/writer。
+- molrs 新增物理算法（MCD/PMSD 的 Rust 实现）—— 若未来想 port，单独
+  立 spec。
+- 任何 deprecation shim：`molcrafts-molpy[molrs]` extras 键直接删除，
+  不保留 alias；老用户升级时会得到 `pip` 的 "extra not provided"
+  warning 即可。
+- molpy 其它子包（io、parser、builder、typifier、reacter、pack、engine）
+  对 molrs 的依赖整理 —— 本 spec 只覆盖 compute + core/box.py。

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ result = mp.tool.polymer(
 | **Simulation interfaces** | Input generation for LAMMPS and CP2K |
 | **Interoperability** | RDKit and OpenBabel adapters for conversion and structure preparation |
 | **Explicit data model** | Distinct `Atomistic`, `Frame`/`Block`, and `ForceField` representations |
-| **Agent interface** | Source-introspection MCP server provided by the [`molmcp`](https://github.com/MolCrafts/molmcp) gateway (local or hosted) |
+| **Agent interface** | Source-introspection MCP server provided by [`molmcp`](https://github.com/MolCrafts/molmcp) (`pip install molcrafts-molmcp`) |
 
 ---
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -12,7 +12,7 @@ Foundational data structures for molecular systems. All available via `import mo
 | `Box` | Periodic simulation cell (3×3 matrix + PBC) | Wrapping, minimum-image distances | Non-periodic systems |
 | `Trajectory` | Ordered sequence of Frames (eager or lazy) | Time-series analysis, streaming I/O | Single-snapshot work |
 | `Topology` | igraph-based bond graph → derived angles/dihedrals | Graph algorithms, connectivity queries | Storing atom properties |
-| `CoarseGrain` | CG molecular graph (beads + CG bonds) | Coarse-grained modelling, CG/AA conversion | All-atom work (use `Atomistic`) |
+| `CoarseGrain` | CG molecular graph (beads + CG bonds) | Coarse-grained modelling; mirrors `Atomistic` | All-atom work (use `Atomistic`) |
 | `Config` | Thread-safe global configuration singleton | Logging level, thread count settings | Per-run overrides (use `Config.temporary`) |
 | `AtomisticForcefield` | Force field container (styles → types → potentials) | Defining parameters before execution | Direct numerical computation |
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -34,6 +34,12 @@ File readers and writers for molecular data, force fields, and trajectories.
 | `read_xyz_trajectory` | XYZ trajectory | read (lazy) |
 | `read_h5_trajectory` | HDF5 trajectory | read (lazy) |
 
+### Logs
+
+| Function | Format | Direction |
+|----------|--------|-----------|
+| `read_LAMMPS_log` | LAMMPS log | read |
+
 ## Canonical examples
 
 ```python
@@ -54,6 +60,11 @@ LAMMPSForceFieldWriter("system.ff").write(ff, atom_types={"CT", "HC"})
 traj = mp.io.read_lammps_trajectory("dump.lammpstrj")
 for frame in traj:
     process(frame)
+
+# Read LAMMPS run output
+log = mp.io.read_LAMMPS_log("log.lammps")
+thermo = log.runs[0].thermo
+print(thermo.columns)
 
 # Write full LAMMPS system (data + ff)
 mp.io.write_lammps_system("output_dir", frame, ff)
@@ -139,3 +150,8 @@ mp.io.write_lammps_system("output_dir", frame, ff)
 
 #### XYZ
 ::: molpy.io.trajectory.xyz
+
+### Log Modules
+
+#### LAMMPS
+::: molpy.io.log.lammps

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -17,9 +17,13 @@ In practice, the workflow is simple:
 
 ## Where MCP support lives
 
-MCP support for MolPy is provided by [`molmcp`](https://github.com/MolCrafts/molmcp), the shared MCP foundation that ships the Provider protocol, source-introspection tools, and safety middleware used across MolCrafts packages. The user-facing artifact is the `molmcp-gateway` app, which aggregates the MolCrafts plugins (`molmcp-molpy`, `molmcp-molexp`, `molmcp-lammps`) behind a single MCP endpoint.
+MCP support for MolPy is provided by [`molmcp`](https://github.com/MolCrafts/molmcp), the shared MCP foundation for the MolCrafts ecosystem. `molmcp` ships:
 
-A single `molmcp-gateway` command starts a coordinated server that exposes MolPy (and any other installed MolCrafts packages) through the same MCP session. MCP code does **not** live in MolPy itself; this keeps the chemistry library focused on its own data model and lets a single MCP launcher stay consistent across the ecosystem.
+- the seven source-introspection tools (described below), applied to any importable MolCrafts package — no per-package wiring required;
+- a `Provider` plugin contract for stateful queries (jobs DBs, workspace catalogs) that introspection cannot answer;
+- security middleware (path-traversal guard, response-size cap, mandatory tool annotations).
+
+`molmcp` imports nothing from MolPy. The pattern is the inverse: a single `python -m molmcp` process inspects whichever of `{molpy, molpack, molrs, molq, molexp}` is importable in the active Python environment and exposes them to the agent. MCP code does **not** live in MolPy itself; this keeps the chemistry library focused on its own data model and keeps the MCP launcher consistent across the ecosystem.
 
 ## The seven tools
 
@@ -39,45 +43,57 @@ Used together, these tools let an agent explore MolPy the same way a human devel
 
 ## Install and register the server
 
-You have two ways to use the gateway: a **local subprocess** that runs in your venv, or a **hosted endpoint** that requires nothing on your machine. Pick one.
+Install `molmcp` from PyPI. The Provider contract is alpha; pin to the 0.2 line:
 
-### Option A — Hosted gateway on Hugging Face Spaces
-
-The MolCrafts ecosystem publishes a public gateway on Hugging Face Spaces. Nothing to install — just point your MCP client at the URL:
-
-```
-https://molcrafts-molmcp-gateway.hf.space/mcp
+```bash
+pip install "molcrafts-molmcp>=0.2,<0.3"
 ```
 
-This endpoint exposes the same tools as the local server (introspection + molpy / molexp / lammps providers) over `streamable-http`.
+Requires Python ≥ 3.12. The PyPI distribution is `molcrafts-molmcp`; the import name and CLI entry are both `molmcp`.
 
-#### Claude Code
+`molmcp` auto-detects whichever of `{molpy, molpack, molrs, molq, molexp}` is importable in the active environment and registers source-introspection over each. Any first-party providers (`MolqProvider`, `MolexpProvider`) and third-party providers registered through the `molmcp.providers` entry-point group are discovered on top.
 
-Add an entry to `.mcp.json` at your repo root:
+Start the server in stdio mode (what MCP clients expect):
+
+```bash
+python -m molmcp
+```
+
+### Claude Code
+
+Project-level registration writes `.mcp.json` at the repository root:
+
+```bash
+claude mcp add molcrafts --scope project -- python -m molmcp
+```
+
+Omit `--scope project` to register at user scope.
+
+!!! tip "Virtual environments"
+    If `python` resolves to the wrong interpreter (or `molmcp` lives in a project-local venv), register the binary explicitly:
+
+    ```bash
+    claude mcp add molcrafts -- /path/to/venv/bin/python -m molmcp
+    ```
+
+    Or let `uv` pick the right environment from a project directory:
+
+    ```bash
+    claude mcp add molcrafts -- uv run --directory /path/to/project python -m molmcp
+    ```
+
+Start a new Claude Code session, then run `/mcp`. You should see `molcrafts` and its tools.
+
+### Claude Desktop
+
+Edit Claude Desktop's `mcpServers` block:
 
 ```json
 {
   "mcpServers": {
-    "molmcp": {
-      "type": "http",
-      "url": "https://molcrafts-molmcp-gateway.hf.space/mcp"
-    }
-  }
-}
-```
-
-Start a new Claude Code session, then run `/mcp`. You should see `molmcp` and its tools.
-
-#### Claude Desktop
-
-Claude Desktop's `mcpServers` block accepts the same shape:
-
-```json
-{
-  "mcpServers": {
-    "molmcp": {
-      "type": "http",
-      "url": "https://molcrafts-molmcp-gateway.hf.space/mcp"
+    "molcrafts": {
+      "command": "python",
+      "args": ["-m", "molmcp"]
     }
   }
 }
@@ -88,98 +104,49 @@ Config file location:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-!!! warning "Cold starts and privacy"
-    The hosted Space sleeps after ~48 h idle. The first request after sleep takes 30–60 s while the container boots; subsequent requests are warm. The Space is also public — anyone with the URL can call its tools. For private use, run the local subprocess (Option B) or self-host the gateway as a private Space.
-
-### Option B — Local subprocess
-
-Install `molmcp` (and its workspace packages) from source. The gateway is not yet on PyPI:
-
-```bash
-pip install \
-    "git+https://github.com/MolCrafts/molmcp.git" \
-    "git+https://github.com/MolCrafts/molmcp.git#subdirectory=packages/molmcp-molpy" \
-    "git+https://github.com/MolCrafts/molmcp.git#subdirectory=packages/molmcp-molexp" \
-    "git+https://github.com/MolCrafts/molmcp.git#subdirectory=packages/molmcp-lammps" \
-    "git+https://github.com/MolCrafts/molmcp.git#subdirectory=apps/molmcp-gateway"
-```
-
-#### Claude Code
-
-```bash
-# Project-level (recommended). Writes .mcp.json in the repo root.
-claude mcp add molmcp --scope project -- molmcp-gateway
-
-# User-level.
-claude mcp add molmcp -- molmcp-gateway
-```
-
-!!! tip "Virtual environments"
-    If `molmcp-gateway` is not on your PATH, register the executable explicitly:
-
-    ```bash
-    claude mcp add molmcp -- /path/to/venv/bin/molmcp-gateway
-    ```
-
-    Or let `uv` launch it from a project directory:
-
-    ```bash
-    claude mcp add molmcp -- uv run --directory /path/to/project molmcp-gateway
-    ```
-
-#### Claude Desktop
-
-```json
-{
-  "mcpServers": {
-    "molmcp": {
-      "command": "molmcp-gateway"
-    }
-  }
-}
-```
-
 Restart Claude Desktop after saving. The MolCrafts tools should appear in the tool picker.
 
 ### Customizing the launch
 
-`molmcp-gateway` exposes a few useful flags. Restrict introspection to MolPy alone, or expose additional roots:
+The CLI exposes a handful of flags. Restrict introspection to MolPy alone, or expose additional roots (any explicit `--import-root` overrides the default auto-detection):
 
 ```bash
-molmcp-gateway --no-default-import-roots --import-root molpy
-molmcp-gateway --import-root molpy --import-root molexp --import-root your_package
+python -m molmcp --import-root molpy
+python -m molmcp --import-root molpy --import-root molexp --import-root your_package
 ```
 
 Serve over HTTP instead of stdio, for clients that cannot launch subprocesses:
 
 ```bash
-molmcp-gateway --transport streamable-http --host 127.0.0.1 --port 8787
+python -m molmcp --transport streamable-http --host 127.0.0.1 --port 8787
 ```
 
-Skip the introspection mount entirely (only domain tools):
+Skip auto-discovery of third-party providers (introspection plus first-party providers only):
 
 ```bash
-molmcp-gateway --no-introspection
+python -m molmcp --no-discover
 ```
+
+Pass `--name <id>` to change the server identifier advertised to clients (defaults to `molmcp`). See the [molmcp CLI reference](https://github.com/MolCrafts/molmcp#install) upstream for the full list.
 
 ## How MCP works
 
-The server runs as a separate process (local subprocess) or a remote HTTP service (hosted gateway). The client connects, asks which tools are available, and then sends tool calls over JSON-RPC.
+`python -m molmcp` runs as a subprocess of the MCP client (Claude Code, Claude Desktop, …). The client asks which tools are available and then sends tool calls over JSON-RPC.
 
 ```text
 ┌─────────────┐   stdio  /  http   ┌──────────────────┐
-│  LLM Client │ ◄────────────────► │  molmcp-gateway  │
-│  (Claude)   │    JSON-RPC msgs   │   (MCP Server)   │
+│  LLM Client │ ◄────────────────► │      molmcp      │
+│  (Claude)   │    JSON-RPC msgs   │   (MCP server)   │
 └─────────────┘                    └──────────────────┘
 ```
 
 A typical exchange looks like this:
 
-1. The client connects to the gateway and requests its capabilities.
-2. The gateway advertises the seven introspection tools plus the domain tools registered by each provider (molpy, molexp, lammps).
+1. The client launches `python -m molmcp` and requests its capabilities.
+2. The server advertises the seven introspection tools (one set per importable MolCrafts package) plus any provider tools registered through the `molmcp.providers` entry-point group — e.g. `molq_list_jobs` from `MolqProvider`, `molexp_list_projects` / `molexp_list_runs` from `MolexpProvider`.
 3. The agent calls those tools to inspect MolPy before writing code.
 
-`stdio` is the default transport for local subprocesses. `streamable-http` and `sse` expose the same protocol over HTTP — used by the hosted gateway and by clients that cannot launch subprocesses.
+`stdio` is the default transport. `streamable-http` and `sse` expose the same protocol over HTTP, used by clients that cannot launch subprocesses.
 
 For example, an agent asked to build a polymer workflow may inspect MolPy like this:
 
@@ -634,6 +601,7 @@ With this information Claude has everything it needs to assemble the script.
 
 ## See Also
 
-- [molmcp](https://github.com/MolCrafts/molmcp) — the MCP foundation: Provider protocol, source-introspection tools, gateway app, and the hosted Space deployment
+- [molmcp](https://github.com/MolCrafts/molmcp) — the MCP foundation: introspection tools, Provider plugin contract, and security middleware shared across the MolCrafts ecosystem
+- [Writing a Provider](https://github.com/MolCrafts/molmcp#adding-domain-tools-for-molcrafts-packages) — extension point for adding domain tools to MolCrafts packages (stateful queries only; introspection covers the API surface)
 - [Tool Layer](../tutorials/tools.md) — what the Tool workflows do and when to use them
 - [Polydisperse Systems](../user-guide/05_polydisperse_systems.ipynb) — end-to-end workflow from distribution to LAMMPS export

--- a/docs/specs/cg-atomistic-mapping-redesign.md
+++ b/docs/specs/cg-atomistic-mapping-redesign.md
@@ -1,0 +1,540 @@
+# Spec: 简化 CoarseGrain 至与 Atomistic 对称
+
+| 字段   | 值                                  |
+| ------ | ----------------------------------- |
+| Status | Draft                               |
+| Target | molpy 0.3.x（pre-1.0，允许 BREAKING）|
+| Owner  | core/cg                             |
+| Layers | core（单文件改写）                   |
+| Risk   | 中：测试需重写，公开 API 形态变化    |
+| Date   | 2026-05-03                          |
+
+---
+
+## 1. Overview / Motivation
+
+`molpy.core.cg` 当前在 core 层钦定了一组"有多种合理替代实现"的领域选择：
+
+- `Bead.atomistic: Atomistic | None` — bead 持有完整 AA 子图
+- `Bead.x/y/z` 由 `from_atomistic` 自动写入（`mean(positions, axis=0)`，命名为 *center of mass* 实为 *center of geometry*）
+- `CoarseGrain.from_atomistic` 强制走 partition mask + crossing-bond 推断
+- `CoarseGrain.to_atomistic` 在数据结构层做反向展开
+
+这些选择本身都不是错的；**错的是 core 不该选边**。COM / COG / weighted centroid、bond 推断策略、AA→CG 投影策略、CG→AA 反向展开重建——每一项都有多个合理实现，分别对应不同 CG 力场（Martini 2 vs 3、VOTCA、PyCGTOOL、DPD、自定义）。一旦 core 钉死其中一条，用户偏离主流时就要绕过 MolPy。
+
+本 spec 的指导原则：
+
+> **CG 在 core 层享有的特权应与 Atomistic 完全相同——不多、不少。**
+
+判据：
+
+> **core 方法 = 在已锁定的约定上、没有第二种合理实现的操作。**
+
+`atomistic.move(delta)` 满足判据（"位置在 x/y/z" 是 SpatialMixin 锁定的约定，加 delta 没有第二种实现）。`atomistic.center_of_mass` 不满足（mass 缺失？hydrogens 包不包？），所以它不在 core 上。
+
+CG 应用同一判据：`bead["atoms"]` 是与 `entity["x/y/z"]` 同档的约定 key（可选、不强制、不验证）；在它上面做 `beads_of(atom)` 这种"包含查询"是 core 一等公民，等价于 `move`。除此之外，所有投影 / 推断 / 派生量算子全部不在 core，**也不在 op 层**——MolPy 不提供。用户按场景自己写一行 numpy / 一个 list comprehension 即可。
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- G1：`Bead` 是空 `Entity`，零强制字段；与 `Atom` 结构完全对称。
+- G2：`CGBond` 是只持两个 Bead endpoints 的 `Link`；与 `Bond` 对称。
+- G3：`CoarseGrain = Struct + MembershipMixin + SpatialMixin + ConnectivityMixin`；公开成员逐项对应 `Atomistic`，仅多一个 `beads_of(atom)`。
+- G4：约定 `bead["atoms"]`（若存在）是 `tuple[Atom, ...]`，与"位置在 `entity["x/y/z"]`" 同档：是 core 方法依赖的约定 key，但 core 不写入、不验证、不强制。
+- G5：BREAKING 一次到位，不保留 deprecated 路径。
+
+### Non-Goals
+
+- NG1：**不**提供 `from_atomistic` / `to_atomistic` / 任何 AA↔CG 投影函数（core、op、builder 都不写）。用户自行实现：
+  ```python
+  cg = CoarseGrain()
+  for group in groups:
+      cg.def_bead(atoms=tuple(group), type="CH3")
+  ```
+- NG2：**不**提供 `bead_center_of_mass` / `bead_center_of_geometry` / `bead_total_mass` / `coarsegrain_positions` 等派生量算子；MolPy 既不在 `core/ops/` 也不在 `op/` 提供。
+- NG3：**不**提供 `infer_cg_bonds` / 自动 bond 推断；用户按需写一个三行 list comprehension。
+- NG4：**不**引入 `Mapping` 类、`source: Atomistic | None` 属性、`_atom_to_beads_cache` 缓存。
+- NG5：**不**改动 `Atom`、`Bond`、`Atomistic`、`Entity`、`Link`、`Struct`、Mixin 任何代码。
+- NG6：**不**改动 `CGSmiles` parser 或新增 IO 格式。
+- NG7：**不**新增 `src/molpy/core/ops/cg.py` 模块。
+
+## 3. Background — 当前实现的具体问题
+
+### 3.1 `Bead.atomistic` 字段是数据结构耦合
+
+`src/molpy/core/cg.py:19-49`：构造器有两条互不相容的路径（dict copy-compat / 正常 `atomistic=` kwarg），`atomistic` 字段在 `__deepcopy__` 后被「神秘地」重设。这是「为了让 `copy.deepcopy` 工作而设计的 API」，不是为了表达 CG 的语义。
+
+更深的问题：把"bead 来自哪些 atom"做成 typed field 强制存在，等价于 `Atom` 强制带 `element` 字段——剥夺了用户表达"纯 CG bead，无 AA 前体"（DPD、Martini 自洽运行、CGSmiles 解析）的能力。
+
+### 3.2 `from_atomistic` 把多个领域选择捆绑
+
+`src/molpy/core/cg.py:439-548`：
+
+```python
+positions_array = np.array(positions)
+center = positions_array.mean(axis=0)            # 钦定 COG
+...
+bead = result.def_bead(
+    atomistic=subgraph,                          # 钦定持有 AA 子图
+    x=float(center[0]), y=float(center[1]), z=float(center[2]),  # 钦定写入位置
+)
+...
+for bond in atomistic.bonds:                     # 钦定推断策略
+    ...
+```
+
+四个独立的领域选择（位置算法、子图持有、自动推断、partition-only 输入）固化在一个工厂里。用户想换其中任何一个，只能整体绕开。
+
+### 3.3 `to_atomistic` 不是数据结构层职责
+
+`src/molpy/core/cg.py:375-437` 既要处理"bead 有 AA 子图就展开"，又要处理"无子图就按 bead 位置造一个虚拟 atom"。这种 CG → AA 反向重建是 builder 层职责（按 CG 模型挑选构象、放置、对齐），不应该是 `CoarseGrain` 自带方法。
+
+### 3.4 与 Atomistic 不对称
+
+`Atomistic` 没有 `from_smiles`、`to_pdb`、`compute_center_of_mass` 这些方法——它们分别属于 `parser`、`io`、`compute` 层。`CoarseGrain` 当前却把对应级别的功能全塞进 core。这是 core 层的不对称特权。
+
+## 4. Proposed Design
+
+### 4.1 全部 core 代码
+
+```python
+# src/molpy/core/cg.py
+from __future__ import annotations
+from typing import Any
+
+from .entity import (
+    ConnectivityMixin,
+    Entities,
+    Entity,
+    Link,
+    MembershipMixin,
+    SpatialMixin,
+    Struct,
+)
+
+
+class Bead(Entity):
+    """Coarse-grained bead.
+
+    Structurally identical to :class:`~molpy.core.atomistic.Atom`: an empty
+    :class:`Entity` with no mandatory fields. All bead state lives in the
+    underlying dict via the :class:`Entity` interface.
+
+    Conventional keys (none enforced, all optional):
+
+    * ``bead["atoms"]`` — ``tuple[Atom, ...]`` of atom references this bead
+      represents, when derived from an :class:`Atomistic`. Required for
+      :meth:`CoarseGrain.beads_of`. Same convention level as
+      ``entity["x/y/z"]`` for spatial operators.
+    * ``bead["x"]``, ``bead["y"]``, ``bead["z"]`` — primary position (used by
+      :class:`SpatialMixin` ``move`` / ``rotate`` / ``scale`` / ``align``).
+    * ``bead["type"]`` — type label.
+    * ``bead["mass"]``, ``bead["charge"]`` — as user needs.
+
+    Deriving anything (centroid from ``atoms``, total mass, etc.) is the
+    user's job; MolPy does not pick a definition.
+    """
+
+
+class CGBond(Link):
+    """CG bond between two beads."""
+
+    def __init__(self, a: Bead, b: Bead, /, **attrs: Any) -> None:
+        assert isinstance(a, Bead), f"a must be Bead, got {type(a)}"
+        assert isinstance(b, Bead), f"b must be Bead, got {type(b)}"
+        super().__init__([a, b], **attrs)
+
+    def __repr__(self) -> str:
+        return f"<CGBond: {self.ibead} - {self.jbead}>"
+
+    @property
+    def ibead(self) -> Bead:
+        return self.endpoints[0]
+
+    @property
+    def jbead(self) -> Bead:
+        return self.endpoints[1]
+
+
+class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
+    """Coarse-grained structure.
+
+    Mirrors :class:`~molpy.core.atomistic.Atomistic` in every public surface
+    except for the single extra method :meth:`beads_of`, which performs the
+    reverse lookup that ``Atomistic`` has no analog for.
+    """
+
+    def __init__(self, **props: Any) -> None:
+        super().__init__(**props)
+        # Call __post_init__ if it exists (template pattern; mirrors Atomistic).
+        if hasattr(self, "__post_init__"):
+            for klass in type(self).__mro__:
+                if klass is CoarseGrain:
+                    break
+                if "__post_init__" in klass.__dict__:
+                    klass.__dict__["__post_init__"](self, **props)
+                    break
+        self.entities.register_type(Bead)
+        self.links.register_type(CGBond)
+
+    @property
+    def beads(self) -> Entities[Bead]:
+        return self.entities[Bead]
+
+    @property
+    def cgbonds(self) -> Entities[CGBond]:  # type: ignore[type-var]
+        return self.links[CGBond]  # type: ignore[return-value]
+
+    def __repr__(self) -> str:
+        from collections import Counter
+        types = Counter(b.get("type", "?") for b in self.beads)
+        comp = (
+            " ".join(f"{t}:{n}" for t, n in sorted(types.items()))
+            if len(types) <= 5 else f"{len(types)} types"
+        )
+        return f"<CoarseGrain, {len(self.beads)} beads ({comp}), {len(self.cgbonds)} bonds>"
+
+    def __len__(self) -> int:
+        return len(self.beads)
+
+    # ---------- factory: parallel to Atomistic.def_atom / def_bond ----------
+
+    def def_bead(self, /, **attrs: Any) -> Bead:
+        """Create and register a new Bead. Parallel to ``Atomistic.def_atom``."""
+        bead = Bead(**attrs)
+        self.entities.add(bead)
+        return bead
+
+    def def_cgbond(self, a: Bead, b: Bead, /, **attrs: Any) -> CGBond:
+        """Create and register a new CGBond. Parallel to ``Atomistic.def_bond``."""
+        bond = CGBond(a, b, **attrs)
+        self.links.add(bond)
+        return bond
+
+    def add_bead(self, bead: Bead, /) -> Bead:
+        self.entities.add(bead)
+        return bead
+
+    def add_cgbond(self, bond: CGBond, /) -> CGBond:
+        self.links.add(bond)
+        return bond
+
+    def del_bead(self, *beads: Bead) -> None:
+        self.remove_entity(*beads)
+
+    def del_cgbond(self, *bonds: CGBond) -> None:
+        self.remove_link(*bonds)
+
+    def def_beads(self, beads_data: list[dict[str, Any]], /) -> list[Bead]:
+        return [self.def_bead(**a) for a in beads_data]
+
+    def def_cgbonds(self, bonds_data, /) -> list[CGBond]:
+        out = []
+        for spec in bonds_data:
+            if len(spec) == 2:
+                a, b = spec; attrs = {}
+            else:
+                a, b, attrs = spec
+            out.append(self.def_cgbond(a, b, **attrs))
+        return out
+
+    def add_beads(self, beads: list[Bead], /) -> list[Bead]:
+        for b in beads: self.entities.add(b)
+        return beads
+
+    def add_cgbonds(self, bonds: list[CGBond], /) -> list[CGBond]:
+        for b in bonds: self.links.add(b)
+        return bonds
+
+    # ---------- the one extra core method: reverse lookup ----------
+
+    def beads_of(self, atom: "Atom") -> tuple[Bead, ...]:
+        """Return all beads whose ``bead["atoms"]`` contains ``atom``.
+
+        Empty tuple if no bead references this atom; multiple if the mapping
+        has overlap. Beads without an ``"atoms"`` key are silently skipped.
+
+        Justified as core (parallel to :meth:`move`): operates on a single
+        conventional key (``"atoms"``) and has no second reasonable
+        implementation. Cost is O(N_beads × mean group size) — no caching;
+        callers needing speed should build their own ``id(atom) → beads``
+        index.
+        """
+        return tuple(b for b in self.beads if atom in b.get("atoms", ()))
+
+    # ---------- selection / type editing (parallel to Atomistic) ----------
+
+    def rename_type(self, old: str, new: str, *, kind: type = Bead) -> int:
+        if issubclass(kind, Link):
+            items = self.links.bucket(kind)
+        else:
+            items = self.entities.bucket(kind)
+        n = 0
+        for it in items:
+            if it.get("type") == old:
+                it["type"] = new; n += 1
+        return n
+
+    def set_property(self, selector, key: str, value: Any, *, kind: type = Bead) -> int:
+        if not callable(selector):
+            raise TypeError("selector must be callable")
+        items = self.links.bucket(kind) if issubclass(kind, Link) else self.entities.bucket(kind)
+        n = 0
+        for it in items:
+            if selector(it):
+                it[key] = value; n += 1
+        return n
+
+    def select(self, predicate) -> "CoarseGrain":
+        if not callable(predicate):
+            raise TypeError("predicate must be callable")
+        selected = [b for b in self.beads if predicate(b)]
+        sub, _ = self.extract_subgraph(selected, radius=0, entity_type=Bead, link_type=Link)
+        return sub  # type: ignore[return-value]
+
+    # ---------- spatial (return self for chaining; same as Atomistic) ----------
+
+    def move(self, delta, *, entity_type: type[Entity] = Bead) -> "CoarseGrain":
+        super().move(delta, entity_type=entity_type); return self
+
+    def rotate(self, axis, angle, about=None, *, entity_type: type[Entity] = Bead) -> "CoarseGrain":
+        super().rotate(axis, angle, about=about, entity_type=entity_type); return self
+
+    def scale(self, factor, about=None, *, entity_type: type[Entity] = Bead) -> "CoarseGrain":
+        super().scale(factor, about=about, entity_type=entity_type); return self
+
+    def align(self, a, b, *, a_dir=None, b_dir=None, flip=False,
+              entity_type: type[Entity] = Bead) -> "CoarseGrain":
+        super().align(a, b, a_dir=a_dir, b_dir=b_dir, flip=flip, entity_type=entity_type)
+        return self
+
+    # ---------- system composition (parallel to Atomistic) ----------
+
+    def __iadd__(self, other: "CoarseGrain") -> "CoarseGrain":
+        self.merge(other); return self
+
+    def __add__(self, other: "CoarseGrain") -> "CoarseGrain":
+        result = self.copy(); result.merge(other); return result
+
+    def replicate(self, n: int, transform=None) -> "CoarseGrain":
+        result = type(self)()
+        for i in range(n):
+            r = self.copy()
+            if transform is not None: transform(r, i)
+            result.merge(r)
+        return result
+```
+
+### 4.2 删除清单
+
+| 当前 API                              | 处置                                              |
+| ------------------------------------- | ------------------------------------------------- |
+| `Bead.__init__(data_dict, atomistic=None, **attrs)` | **删除**双签名 hack；改为 `Bead(**attrs)` |
+| `Bead.atomistic` 字段                 | **删除**；用户用 `bead["atoms"]` 约定键           |
+| `Bead.__deepcopy__`                   | **删除**；用 `Entity` 默认 deepcopy（dict 深拷贝） |
+| `CoarseGrain.from_atomistic(...)`     | **删除**；用户自己写（见 §5）                     |
+| `CoarseGrain.to_atomistic(...)`       | **删除**                                          |
+| `def_bead(atomistic=...)` 参数        | **删除**；统一为 `def_bead(**attrs)`              |
+
+### 4.3 不新增的清单
+
+明确不在本 spec 也不在后续 spec 提供：
+
+- `core/ops/cg.py` 模块
+- `op/cg.py` 模块（中的 CG 相关 helper）
+- `bead_center_of_mass` / `bead_center_of_geometry` / `bead_total_mass` / `bead_total_charge` / `coarsegrain_positions` / `coarsegrain_by_groups` / `infer_cg_bonds` / `bead_centroid` 任何函数
+
+如果未来用户反复手写同一段代码，可在那时按需起新 spec 提议加入 op 层。本次不预设。
+
+### 4.4 Module Changes
+
+| File                          | Action  | Description                                       |
+| ----------------------------- | ------- | ------------------------------------------------- |
+| `src/molpy/core/cg.py`        | Rewrite | 见 §4.1，约 150 行                                  |
+| `src/molpy/__init__.py`       | No-op   | `Bead`、`CGBond`、`CoarseGrain` 已导出              |
+| `tests/test_core/test_cg.py`  | Rewrite | 删除映射、派生量、to_atomistic 相关；保留 def/del/ select/spatial/merge 等结构性测试 |
+| `docs/api/core.md`            | Modify  | 更新 Bead / CoarseGrain 描述：去掉"bidirectional conversion"措辞，明确"约定 key" |
+
+### 4.5 Layer Validation
+
+仍在 **core** 层。新 `core/cg.py` 仅依赖 `core.entity`；不再有 `from .atomistic import` 也不依赖 numpy。九层依赖规则收紧。
+
+## 5. Behavior Examples
+
+### 5.1 纯 CG（无 AA 前体）
+
+```python
+cg = CoarseGrain()
+b1 = cg.def_bead(type="A", x=0.0, y=0.0, z=0.0, charge=-1.0)
+b2 = cg.def_bead(type="B", x=3.0, y=0.0, z=0.0)
+cg.def_cgbond(b1, b2, k=120.0)
+
+cg.move([1, 0, 0])           # SpatialMixin works on bead["x/y/z"]
+assert b1["x"] == 1.0
+assert "atoms" not in b1     # 没有 AA 前体
+```
+
+### 5.2 从 Atomistic 投影（用户自己写）
+
+MolPy **不提供**投影函数。用户按场景自己写：
+
+```python
+import numpy as np
+
+def my_coarsegrain(ato, mask):
+    """Partition + crossing-bond inference + COG position. User code."""
+    cg = CoarseGrain()
+    bead_of = {}
+    for idx in np.unique(mask):
+        atoms = tuple(a for a, m in zip(ato.atoms, mask) if m == idx)
+        pos = np.mean([[a["x"], a["y"], a["z"]] for a in atoms], axis=0)
+        bead_of[int(idx)] = cg.def_bead(
+            atoms=atoms,
+            x=float(pos[0]), y=float(pos[1]), z=float(pos[2]),
+        )
+    seen = set()
+    for bond in ato.bonds:
+        # naive O(N) lookup — user can index if needed
+        ai = next(i for i, a in enumerate(ato.atoms) if a is bond.itom)
+        aj = next(i for i, a in enumerate(ato.atoms) if a is bond.jtom)
+        bi, bj = int(mask[ai]), int(mask[aj])
+        if bi == bj: continue
+        key = (bi, bj) if bi < bj else (bj, bi)
+        if key in seen: continue
+        seen.add(key)
+        cg.def_cgbond(bead_of[bi], bead_of[bj])
+    return cg
+```
+
+注：MolPy 不替用户做这个选择。换 Martini 3 (COG 含 H)、加权 COM、virtual site、shared-atom mapping、用 ITP 显式声明 bond——都是用户改这段函数的事，与 core 无关。
+
+### 5.3 反向查询：唯一的 core 便利方法
+
+```python
+cg = my_coarsegrain(ato, mask)
+beads = cg.beads_of(ato.atoms[0])     # tuple[Bead, ...]
+assert len(beads) == 1                 # disjoint partition
+```
+
+如果用户的映射有 overlap：
+
+```python
+b1 = cg.def_bead(atoms=(a, b))
+b2 = cg.def_bead(atoms=(b, c))
+assert cg.beads_of(b) == (b1, b2)      # 两个 bead
+```
+
+### 5.4 PolymerBuilder 反向（未来 spec）
+
+PolymerBuilder 看到的 CG 没有任何 MolPy 钦定语义，纯靠约定 key 驱动：
+
+```python
+# 未来 builder/cg.py 的伪代码（不在本 spec 范围）
+def expand(cg, fragment_library):
+    ato = Atomistic()
+    for bead in cg.beads:
+        frag = fragment_library[bead["type"]]   # 用 type 当 key
+        place_fragment_at(frag, bead["x"], bead["y"], bead["z"])
+        ato.merge(frag)
+    return ato
+```
+
+bead 只暴露 `dict[key, value]`，builder 选哪些 key、怎么解释——自由。
+
+## 6. Migration / Breaking Changes
+
+| #  | Before                                                | After                                                   |
+| -- | ----------------------------------------------------- | ------------------------------------------------------- |
+| B1 | `Bead(atomistic=sub, type="CH3")`                     | `Bead(atoms=tuple(sub.atoms), type="CH3")`              |
+| B2 | `bead.atomistic`（属性）                                | `bead.get("atoms")`（dict key）                         |
+| B3 | `cg.def_bead(atomistic=sub, x=…, y=…, z=…)`           | `cg.def_bead(atoms=tuple(sub.atoms), x=…, y=…, z=…)`    |
+| B4 | `cg.from_atomistic(ato, mask)`                        | 用户自己写一个函数（见 §5.2）                            |
+| B5 | `cg.to_atomistic()`                                   | 用户在 builder 层按 CG 模型重建                          |
+| B6 | `Bead.__init__(data_dict, atomistic=None, **attrs)`   | `Bead(**attrs)`                                         |
+| B7 | bond inference 永远开启                                 | 用户在投影函数里写明                                     |
+| B8 | bead 位置由 `from_atomistic` 自动写入                   | 用户在投影函数里显式 `def_bead(x=..., y=..., z=...)`     |
+
+迁移步骤：
+
+1. 凡 `Bead(atomistic=X)` → `Bead(atoms=tuple(X.atoms))`，或如不需要原子映射，直接 `Bead(type=…)`。
+2. 凡 `bead.atomistic` 读取 → `bead.get("atoms", ())`。
+3. 凡 `cg.from_atomistic(ato, mask)` → 复制 §5.2 的代码片段，或改写为自己版本。
+4. 凡 `cg.to_atomistic()` → 删除调用，按需在 builder 层重建。
+5. 凡 `bead.x / bead.y / bead.z` 读取 → 不变（仍走 dict）；如需从 atom 派生，用户自己写一行 numpy。
+
+## 7. Testing Strategy
+
+### 7.1 删除（`tests/test_core/test_cg.py`）
+
+整组移除：
+
+- `test_bead_with_atomistic_mapping`（第 48–55 行）
+- `TestToAtomisticConversion`（第 320–358 行）
+- `test_convert_atomistic_with_mask`、`test_convert_creates_multiple_beads`、`test_bead_position_is_center_of_mass`、`test_infer_cgbonds_from_atomistic_bonds`、`test_mask_length_validation`（第 364–442 行）
+- `TestRoundTripConversion`（第 445–469 行）
+
+### 7.2 新增 / 改写
+
+保留并扩充以下测试，全部对应 Atomistic 的同名测试逻辑：
+
+- `test_bead_is_empty_entity`：`Bead()` 可创建，无强制字段，`bead.data == {}`。
+- `test_bead_dict_interface`：`Bead(type="A", x=1.0)["type"] == "A"`、`bead["x"] == 1.0`。
+- `test_bead_deepcopy_copies_dict_only`：`copy.deepcopy(Bead(atoms=(a, b)))["atoms"][0] is a`（refs 共享）。
+- `test_def_bead_registers_in_entities`：`cg.def_bead(...) in cg.beads`。
+- `test_def_cgbond_registers_in_links`。
+- `test_cgbond_endpoints`：`bond.ibead is a`、`bond.jbead is b`。
+- `test_beads_of_disjoint`：`cg.beads_of(atom) == (bead,)`。
+- `test_beads_of_overlap`：同一 atom 在两 bead，`len(cg.beads_of(a)) == 2`。
+- `test_beads_of_unknown_returns_empty`：`cg.beads_of(unknown) == ()`。
+- `test_beads_of_skips_beads_without_atoms_key`：mixed bead，部分有 `atoms` 部分没。
+- `test_move_translates_bead_xyz`：与 `test_atomistic.py::test_move` 平行。
+- `test_merge`、`test_select`、`test_replicate`：与 Atomistic 平行。
+
+### 7.3 不新增的测试模块
+
+不创建 `tests/test_core/test_ops_cg.py` 或 `tests/test_op/test_cg.py`——没有对应实现。
+
+### 7.4 覆盖率目标
+
+| Module                    | 覆盖率目标 |
+| ------------------------- | ---------- |
+| `src/molpy/core/cg.py`    | ≥ 95%      |
+
+### 7.5 全量回归
+
+- `pytest tests/ -m "not external" -v`：无回归。
+- `grep -rn "bead\.atomistic\|to_atomistic\|from_atomistic" src/ tests/ docs/`：除 CHANGELOG 外应为空。
+
+## 8. Performance Considerations
+
+新 `core/cg.py` 不含任何重型算法，性能特征即 `Struct` / `Entity` 自身：
+
+| 操作              | 复杂度                   |
+| ----------------- | ------------------------ |
+| `def_bead`        | O(1)                     |
+| `def_cgbond`      | O(1)                     |
+| `beads_of(atom)`  | O(N_beads × ⟨\|atoms\|⟩) |
+| `merge` / `copy`  | 同 Atomistic              |
+
+`beads_of` 不缓存：缓存失效逻辑会污染 `def_bead` / `add_bead` / `remove_entity` / `merge` 多处，工程债不划算。需要快查的用户在自己代码里建 `dict[id(atom), list[Bead]]`。
+
+旧 `from_atomistic` 中的 O(N×M) bond 推断问题随该方法删除而消失；用户写新版时若用 `dict` 存 atom→idx 映射即可达到 O(N+M)（见 §5.2 注释）。
+
+## 9. Open Questions
+
+| #  | Question                                                              | 当前默认                                                  |
+| -- | --------------------------------------------------------------------- | --------------------------------------------------------- |
+| Q1 | `bead["atoms"]` 这个约定 key 名要不要写进 `core/cg.py` 的常量？        | 不写。docstring 描述即可；硬编码在 `beads_of` 一处。      |
+| Q2 | 用户写 `my_coarsegrain` 模板函数的反复劳动会不会成为负担？             | 暂不解决。等出现 ≥3 处重复后起新 spec 加 op helper。       |
+| Q3 | 反向 builder（CG → AA via fragment library）何时立项？                  | 独立 spec，依赖 fragment library 设计先行。               |
+| Q4 | CG angles / dihedrals 是否进 link 体系？                                | 本 spec 不涉及；后续视 CG 力场需求评估。                  |
+| ~~Q5~~ | ~~`CoarseGrain.to_frame()` I/O 入口何时补？~~ | **已实现**：与 `Atomistic.to_frame` 对称的 `beads` / `cgbonds` 双 block 形式；endpoints 索引字段命名为 `ibead` / `jbead`。 |
+
+## 10. Critical Files
+
+| 路径                                  | 作用                              |
+| ------------------------------------- | --------------------------------- |
+| `src/molpy/core/cg.py`                | 整个模块重写（约 150 行）          |
+| `tests/test_core/test_cg.py`          | 测试删除 + 改写（向 Atomistic 对齐） |
+| `docs/api/core.md`                    | 描述更新                          |

--- a/docs/tutorials/08_coarsegrain.md
+++ b/docs/tutorials/08_coarsegrain.md
@@ -1,0 +1,145 @@
+# Coarse-Grained Structure
+
+This page explains the `CoarseGrain` data structure, why it stays out of the way of force-field choices, and how to project an atomistic system onto a coarse-grained one.
+
+## A coarse-grained structure is the same kind of object as an atomistic one
+
+In MolPy, `CoarseGrain` is the analog of `Atomistic` for systems where the basic unit is a *bead* rather than an atom. A bead may correspond to a group of atoms in a fine-grained model (Martini, MARTINI 3, VOTCA-style mappings), or it may have no atomistic precursor at all (DPD, equilibrated Martini snapshots, polymer scaffolds awaiting backmapping).
+
+The shape of `CoarseGrain` is identical to that of `Atomistic`. The same factory methods, the same spatial operations, the same composition operators, the same dict-based property access. If you know how to build an atomistic system, you already know how to build a coarse-grained one.
+
+```python
+import molpy as mp
+
+cg = mp.CoarseGrain(name="lipid")
+b1 = cg.def_bead(type="P4", x=0.0, y=0.0, z=0.0)
+b2 = cg.def_bead(type="C1", x=4.7, y=0.0, z=0.0)
+cg.def_cgbond(b1, b2, k=120.0)
+
+cg.move([1, 0, 0])
+print(b1["x"])   # 1.0
+```
+
+## Beads carry whatever fields you decide they should carry
+
+`Bead` is a dict-like object with no mandatory fields. Position, mass, charge, type label, atom-level provenance — every one of these is a key you set or omit, just like on `Atom`. There is no force-field-specific schema; there is no built-in opinion about how a bead's position relates to the atoms it represents.
+
+This deliberate absence of structure is the design point. A Martini 3 bead uses the geometric centre of its constituent heavy atoms (with hydrogens). A Martini 2 bead uses the mass-weighted centre. A VOTCA-style bead uses arbitrary per-atom weights. A DPD bead has no atoms at all and stores its position directly. MolPy refuses to pick one of these conventions for you, because each is correct in its own context.
+
+```python
+# A Martini-flavoured bead: type label + position
+cg.def_bead(type="P4", x=1.0, y=2.0, z=3.0)
+
+# A bead that remembers which atoms it represents
+ato = mp.Atomistic()
+c1 = ato.def_atom(element="C", x=0.0, y=0.0, z=0.0)
+c2 = ato.def_atom(element="C", x=1.5, y=0.0, z=0.0)
+cg.def_bead(atoms=(c1, c2), type="CG_C2")
+
+# A bead that uses a vermouth-style residue template key
+cg.def_bead(template="ALA_BB", residue_id=12)
+```
+
+None of these layouts is "correct" or "preferred". The data structure simply records what you put into it.
+
+## One convention key gets first-class support
+
+There is one and only one convention key the core data structure recognises: `bead["atoms"]`. When present, it is interpreted as a tuple of `Atom` references that the bead represents. This convention exists for the same reason `entity["x/y/z"]` exists — to give the spatial mixin something to operate on. Where `move(delta)` requires `x/y/z`, the reverse-lookup method `beads_of(atom)` requires `atoms`.
+
+```python
+ato = mp.Atomistic()
+a = ato.def_atom(element="C")
+b = ato.def_atom(element="C")
+c = ato.def_atom(element="O")
+
+bead_ab = cg.def_bead(atoms=(a, b), type="CC")
+bead_c  = cg.def_bead(atoms=(c,),     type="O")
+
+cg.beads_of(a)   # (bead_ab,)
+cg.beads_of(c)   # (bead_c,)
+cg.beads_of(b)   # (bead_ab,)
+```
+
+The lookup is a linear scan; for hot loops over many atoms, the user is expected to build a private `id(atom) → list[Bead]` index. The data structure deliberately does not cache, because cache invalidation would introduce coupling with every factory method on `CoarseGrain`.
+
+`beads_of` returns multiple beads if the mapping has overlap, and an empty tuple if the atom is not referenced by any bead.
+
+```python
+shared = cg.def_bead(atoms=(a,), type="virtual")
+cg.beads_of(a)   # (bead_ab, shared)
+```
+
+Shared atoms are real in production force fields. Martini uses them in fused aromatic rings; AdResS-style hybrid resolution uses them at the AA/CG boundary. The data structure does not need to know any of that — it only needs to permit the user to express it.
+
+## Projecting from atomistic is your code, not the framework's
+
+There is no `from_atomistic` factory and no `to_atomistic` method on `CoarseGrain`. This is not an oversight. The act of projecting an atomistic system onto a coarse-grained one bundles several independent decisions: how to partition atoms into beads, how to compute each bead's position, whether to infer CG bonds from crossing atomistic bonds or to declare them explicitly, and what additional properties to copy. Every one of those decisions has more than one defensible answer.
+
+The framework's role is to make your projection easy to express, not to choose its policies for you.
+
+```python
+import numpy as np
+
+def my_coarsegrain(ato, mask):
+    """A simple disjoint-partition projection with COG positions and
+    crossing-bond inference. Adapt freely."""
+    cg = mp.CoarseGrain()
+    bead_of = {}
+    for idx in np.unique(mask):
+        atoms = tuple(a for a, m in zip(ato.atoms, mask) if m == idx)
+        pos = np.mean([[a["x"], a["y"], a["z"]] for a in atoms], axis=0)
+        bead_of[int(idx)] = cg.def_bead(
+            atoms=atoms,
+            x=float(pos[0]), y=float(pos[1]), z=float(pos[2]),
+        )
+
+    atom_to_idx = {id(a): i for i, a in enumerate(ato.atoms)}
+    seen = set()
+    for bond in ato.bonds:
+        bi = int(mask[atom_to_idx[id(bond.itom)]])
+        bj = int(mask[atom_to_idx[id(bond.jtom)]])
+        if bi == bj:
+            continue
+        key = (bi, bj) if bi < bj else (bj, bi)
+        if key in seen:
+            continue
+        seen.add(key)
+        cg.def_cgbond(bead_of[bi], bead_of[bj])
+    return cg
+```
+
+This is the entire AA→CG path for a basic Martini-style mapping in twenty lines. Switching to mass-weighted positions, residue-based partitioning, explicit ITP-declared bonds, or per-bead virtual sites is a matter of changing this function — not of fighting the framework's choices.
+
+## Round-tripping is the builder's job, not the data structure's
+
+The reverse direction — turning a coarse-grained snapshot back into an atomistic one — is also intentionally absent from `CoarseGrain`. Backmapping is a constructive operation: it requires a fragment library keyed by bead type, a placement procedure that respects bond geometry, and usually a relaxation step. Tools like *Backward*, *initram*, and *vermouth* implement this as a pipeline, not as a single method. In MolPy the same role belongs to the polymer builder layer, which consumes `CoarseGrain` snapshots and produces `Atomistic` outputs through fragment templates that the user supplies.
+
+For the present page, the takeaway is simpler: `CoarseGrain` is a place to put beads and the bonds between them. Everything else — projection, backmapping, energetics, force-field assignment — happens around it.
+
+## Spatial and compositional operations work exactly as on Atomistic
+
+Because `CoarseGrain` mirrors `Atomistic`'s public surface, the spatial mixin and the system-composition operators behave identically.
+
+```python
+cg2 = cg.copy()
+cg2.move([10, 0, 0])
+combined = cg + cg2
+
+cg.replicate(4, transform=lambda copy, i: copy.move([i * 5, 0, 0]))
+```
+
+You can select a subset of beads by predicate, rename bead types in bulk, or attach arbitrary metadata to the structure itself.
+
+```python
+cg.select(lambda b: b.get("type") == "P4")
+cg.rename_type("P4", "Q4")
+cg.set_property(lambda b: b["x"] > 0, "region", "right")
+```
+
+These methods carry no implicit assumptions about what a "type" means, what a "region" is, or how positions relate to physical space. They are graph operations on a graph whose nodes happen to be beads.
+
+## When to use CoarseGrain instead of Atomistic
+
+Use `CoarseGrain` when you want the type system to make it explicit that a node is a bead, not an atom. Use it when you intend to serialize the structure as a CG topology (Martini ITP, LAMMPS DATA with a CG model, etc.) rather than as an all-atom one. Use it when a downstream builder will consume it and produce an atomistic output.
+
+Conversely, if your beads are physically interchangeable with atoms in your workflow — for example, if you are running a single-bead-per-atom united-atom model — there is no harm in using `Atomistic` directly and treating the atoms as beads. The data structures are deliberately the same shape; the choice between them is a labelling decision, not a capability decision.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -60,6 +60,7 @@ The diagram below illustrates the standard data flow through a MolPy pipeline. E
 - [Trajectory](05_trajectory.md) — time-ordered frame sequences with lazy loading
 - [Selector](06_selector.md) — composable, predicate-based atom filters over `Block` columns
 - [Wrapper and Adapter](07_wrapper_and_adapter.md) — subprocess execution boundaries and in-memory representation bridges
+- [Coarse-Grained Structure](08_coarsegrain.md) — beads as a graph, the convention-key boundary, and user-defined AA→CG projection
 - [I/O](io.md) — reading, writing, and extending molecular, trajectory, and force-field formats
 - [Tool Layer](tools.md) — packaged multi-step workflows built on top of MolPy's lower-level modules
 - [Engine](engine.md) — generation and execution of MD engine input files for LAMMPS, CP2K, and OpenMM

--- a/docs/tutorials/io.md
+++ b/docs/tutorials/io.md
@@ -124,6 +124,39 @@ mp.io.write_h5_trajectory("output.h5", frames)
 | HDF5 | `read_h5_trajectory` | `write_h5_trajectory` | Binary, compressed, fast |
 
 
+## Log files: simulation run metadata
+
+LAMMPS log files are different from data and trajectory files: they describe what LAMMPS did during each `run`, not where atoms were. MolPy preserves that structure. A parsed log contains the LAMMPS header, a tuple of `runs`, and raw text for anything that is not yet represented by a dedicated field.
+
+The key idea is: **use `read_LAMMPS_log` when you need run-level diagnostics such as thermo output, loop timing, load balance, neighbor statistics, or warnings.** The thermo table stays in a NumPy-backed dataclass so downstream analysis can use dynamic LAMMPS column names directly.
+
+In practice, each run is accessed in the same order it appears in the log:
+
+```python
+log = mp.io.read_LAMMPS_log("log.lammps")
+run = log.runs[0]
+
+print(run.thermo.columns)
+print(run.thermo.data["Temp"].mean())
+print(run.loop_time.seconds)
+print(run.neighbor_statistics.dangerous_builds)
+```
+
+The parser also keeps compatibility with older thermo-only code. `LAMMPSLog(path).read()` still supports `log["stages"]`, while new code should prefer `log.runs`.
+
+```python
+legacy = mp.io.LAMMPSLog("log.lammps").read()
+first_stage = legacy["stages"][0]
+print(first_stage["Step"][0])
+```
+
+### Supported log formats
+
+| Format | Read | Write | Notes |
+|--------|------|-------|-------|
+| LAMMPS log | `read_LAMMPS_log` | — | Returns nested dataclasses aligned with LAMMPS run output |
+
+
 ## Force field files: ForceField in, ForceField out
 
 Force field readers parse parameter files into `ForceField` objects. Force field writers serialize `ForceField` objects into engine-specific formats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "python-igraph>=1.0.0",
     "lark>=1.3.1",
     "pint>=0.24",
+    "molcrafts-molrs>=0.0.8",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "python-igraph>=1.0.0",
     "lark>=1.3.1",
     "pint>=0.24",
-    "molcrafts-molrs>=0.0.8",
+    "molcrafts-molrs>=0.0.10",
 ]
 
 [tool.setuptools.dynamic]

--- a/src/molpy/compute/__init__.py
+++ b/src/molpy/compute/__init__.py
@@ -20,11 +20,14 @@ Example usage:
 
 from .base import Compute
 from .mcd import MCDCompute
+from .neighborlist import NeighborList
 from .pmsd import PMSDCompute
+from .rdf import RDF
 from .result import MCDResult, PMSDResult, Result, TimeSeriesResult
 from .time_series import TimeAverage, TimeCache, compute_acf, compute_msd
 
-# Optional RDKit compute nodes
+# Optional RDKit compute nodes (slated for removal in Phase 3 — replaced by
+# the molrs-backed embed pipeline).
 try:  # pragma: no cover
     from .rdkit import Generate3D, OptimizeGeometry
 
@@ -42,6 +45,8 @@ __all__ = [
     "PMSDResult",
     "MCDCompute",
     "PMSDCompute",
+    "NeighborList",
+    "RDF",
     "TimeCache",
     "TimeAverage",
     "compute_msd",

--- a/src/molpy/compute/neighborlist.py
+++ b/src/molpy/compute/neighborlist.py
@@ -1,0 +1,43 @@
+"""Spatial neighbor list — molrs-backed.
+
+Returns ``molrs.NeighborList`` directly (no molpy wrapper). Coordinates are
+stacked once via ``frame["atoms"][["x", "y", "z"]]`` (the only unavoidable
+copy, internal to ``Block.__getitem__(list)``); from that point through to
+the returned indices/distances the path is zero-copy borrowed views into
+the molrs Rust buffers.
+"""
+
+from __future__ import annotations
+
+import molrs
+
+from .base import Compute
+
+
+class NeighborList(Compute):
+    """Spatial neighbor-pair query within a cutoff radius.
+
+    Parameters
+    ----------
+    cutoff : float
+        Cutoff radius in Angstroms.
+
+    Examples
+    --------
+    >>> nlist = NeighborList(cutoff=2.5)(frame)
+    >>> nlist.n_pairs
+    1834
+    """
+
+    def __init__(self, cutoff: float):
+        super().__init__(cutoff=float(cutoff))
+        self.cutoff = float(cutoff)
+
+    def _compute(self, frame) -> molrs.NeighborList:
+        if frame.box is None:
+            raise ValueError("frame.box is required for spatial neighbor search")
+        # Block list-indexing returns (N, 3) via np.column_stack — single
+        # unavoidable copy. Box passes through directly (molpy.Box IS-A
+        # molrs.Box).
+        xyz = frame["atoms"][["x", "y", "z"]]
+        return molrs.NeighborQuery(frame.box, xyz, self.cutoff).query_self()

--- a/src/molpy/compute/rdf.py
+++ b/src/molpy/compute/rdf.py
@@ -1,0 +1,69 @@
+"""Radial distribution function g(r) — molrs-backed.
+
+Returns ``molrs.RDFResult`` directly (no molpy wrapper). The result is
+finalized eagerly inside ``molrs.RDF.compute``, so ``result.rdf`` is the
+normalized g(r) and not the raw histogram.
+"""
+
+from __future__ import annotations
+
+import molrs
+
+from .base import Compute
+
+
+class RDF(Compute):
+    """Histogram pair distances into g(r) over one or more frames.
+
+    Parameters
+    ----------
+    n_bins : int
+        Number of histogram bins.
+    r_max : float
+        Upper edge of the last bin in Angstroms.
+    r_min : float, default 0.0
+        Lower edge of bin 0 in Angstroms.
+
+    Notes
+    -----
+    RDF takes two inputs (frames + neighbor lists) and therefore overrides
+    ``__call__`` rather than ``_compute``. It is not directly compatible
+    with single-input molexp workflows; chain via an explicit dataflow node
+    if needed.
+    """
+
+    def __init__(self, n_bins: int, r_max: float, r_min: float = 0.0):
+        super().__init__(n_bins=n_bins, r_max=r_max, r_min=r_min)
+        self._inner = molrs.RDF(n_bins, r_max, r_min)
+
+    def __call__(self, frames, neighbors) -> molrs.RDFResult:
+        molpy_frames = self._as_list(frames)
+        molrs_frames = [self._molrs_frame_view(f) for f in molpy_frames]
+        return self._inner.compute(molrs_frames, self._as_list(neighbors))
+
+    @staticmethod
+    def _molrs_frame_view(frame) -> molrs.Frame:
+        """Build a molrs.Frame whose simbox is the molpy frame's box.
+
+        molrs.RDF.compute only reads ``simbox_ref()`` from the frame
+        (coordinates come from the NeighborList), so this view does not
+        copy any coordinate data — it just attaches the existing Box
+        (which IS-A molrs.Box) to a fresh molrs.Frame.
+        """
+        if frame.box is None:
+            raise ValueError("frame.box is required for RDF computation")
+        mf = molrs.Frame()
+        mf.simbox = frame.box
+        return mf
+
+    def _compute(self, input):  # pragma: no cover — RDF uses __call__ directly
+        raise NotImplementedError(
+            "RDF takes two inputs (frames, neighbors); call directly or use "
+            "RDF.__call__(frames, neighbors)."
+        )
+
+    @staticmethod
+    def _as_list(x):
+        if isinstance(x, (list, tuple)):
+            return list(x)
+        return [x]

--- a/src/molpy/core/_molrs.py
+++ b/src/molpy/core/_molrs.py
@@ -1,0 +1,95 @@
+"""Conversion helpers between :class:`molpy.Atomistic` and ``molrs.Atomistic``.
+
+The molrs Python extension exposes its own ``Atomistic`` class with a
+columnar Frame interface. molpy keeps its richer Entity-based ``Atomistic``;
+Rust-backed molpy modules marshal both directions at the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import molrs
+
+from .atomistic import Atomistic
+
+
+def to_molrs(mol: Atomistic) -> "molrs.Atomistic":
+    """Build a ``molrs.Atomistic`` mirroring ``mol``'s atoms and bonds."""
+    out = molrs.Atomistic()
+    indices: dict[int, int] = {}
+    for atom in mol.atoms:
+        symbol = str(atom.get("element") or atom.get("symbol") or "C")
+        x = atom.get("x")
+        y = atom.get("y")
+        z = atom.get("z")
+        if x is None or y is None or z is None:
+            idx = out.add_atom(symbol)
+        else:
+            idx = out.add_atom(symbol, float(x), float(y), float(z))
+        indices[id(atom)] = idx
+
+    for bond in mol.bonds:
+        i = indices.get(id(bond.itom))
+        j = indices.get(id(bond.jtom))
+        if i is None or j is None:
+            continue
+        out.add_bond(i, j)
+        order = bond.get("order")
+        if order is not None:
+            out.set_bond_order(i, j, float(order))
+    return out
+
+
+def from_molrs(
+    mol_rs: "molrs.Atomistic", template: Atomistic | None = None
+) -> Atomistic:
+    """Build a fresh :class:`molpy.Atomistic` from ``mol_rs``.
+
+    If ``template`` is provided and its atom count matches, per-atom
+    attributes other than coordinates are copied across by index so that
+    downstream molpy code sees the same atoms it gave us.
+    """
+    frame = mol_rs.to_frame()
+    atoms_block = frame["atoms"]
+    bonds_block = frame["bonds"]
+
+    elements = list(atoms_block.view("element"))
+    xs = list(atoms_block.view("x"))
+    ys = list(atoms_block.view("y"))
+    zs = list(atoms_block.view("z"))
+
+    template_atoms = list(template.atoms) if template is not None else []
+    use_template = len(template_atoms) == len(elements)
+
+    out = Atomistic()
+    new_atoms = []
+    for i, sym in enumerate(elements):
+        attrs: dict[str, Any] = {}
+        if use_template:
+            for k, v in template_atoms[i].data.items():
+                if k in {"x", "y", "z"}:
+                    continue
+                attrs[k] = v
+        attrs["element"] = str(sym)
+        attrs["x"] = float(xs[i])
+        attrs["y"] = float(ys[i])
+        attrs["z"] = float(zs[i])
+        new_atoms.append(out.def_atom(**attrs))
+
+    bond_keys = bonds_block.keys()
+    if "atomi" in bond_keys and "atomj" in bond_keys:
+        i_arr = list(bonds_block.view("atomi"))
+        j_arr = list(bonds_block.view("atomj"))
+        order_arr = (
+            list(bonds_block.view("order"))
+            if "order" in bond_keys
+            else [1.0] * len(i_arr)
+        )
+        for i, j, order in zip(i_arr, j_arr, order_arr):
+            ii = int(i)
+            jj = int(j)
+            if 0 <= ii < len(new_atoms) and 0 <= jj < len(new_atoms):
+                out.def_bond(new_atoms[ii], new_atoms[jj], order=float(order))
+
+    return out

--- a/src/molpy/core/box.py
+++ b/src/molpy/core/box.py
@@ -1,84 +1,161 @@
 # author: Roy Kid
 # contact: lijichen365@126.com
 # date: 2023-09-29
-# version: 0.0.1
+# version: 0.1.0  — molrs.Box inheritance refactor
 
 from enum import Enum
 
+import molrs
 import numpy as np
 from numpy.typing import ArrayLike
 
-from .region import PeriodicBoundary
 
+class Box(molrs.Box):
+    """Simulation box — molpy front for the molrs spatial primitive.
 
-class Box(PeriodicBoundary):
-    """Simulation box representing a periodic domain in 3D space.
+    Inherits ``molrs.Box`` directly, so a ``molpy.Box`` instance is
+    accepted by every molrs API (``NeighborQuery``, ``RDF``, ``wrap``,
+    ``isin``, …) without conversion. molpy adds:
 
-    The box is defined by a 3x3 upper-triangular matrix whose columns are
-    the lattice vectors, an origin point, and per-axis periodic boundary
-    flags.  Three styles are supported:
+    - the ``Style`` enum (FREE / ORTHOGONAL / TRICLINIC),
+    - molpy-style accessors (``lx``, ``ly``, ``lz``, ``xy``, ``xz``,
+      ``yz``, ``a``, ``b``, ``c``, ``lengths``, ``angles``, ``tilts``,
+      ``bounds``, ``xlo``/``xhi``/…),
+    - convenience factories (``cubic``, ``orth``, ``tric``,
+      ``from_lengths_angles``, ``from_bounds``, ``from_box``),
+    - PBC-aware geometry helpers (``wrap``, ``unwrap``, ``diff``,
+      ``dist``, ``make_fractional``, ``make_absolute``,
+      ``get_distance_between_faces``, ``get_images``).
 
-    - **FREE** -- no boundaries (zero matrix).
-    - **ORTHOGONAL** -- axis-aligned cuboid (diagonal matrix).
-    - **TRICLINIC** -- general parallelepiped (upper-triangular matrix
-      with at least one nonzero off-diagonal element).
-
-    All length quantities are in Angstroms.  Angles are in degrees
-    unless stated otherwise.
+    **Immutable.** State lives in the molrs base; per-axis setters and
+    ``set_*`` methods were removed in this refactor (use one of the
+    classmethod factories to construct a new ``Box`` instead). This
+    matches molpy's own ``coding-style.md`` "avoid mutation" rule.
 
     Args:
-        matrix: A 3x3 upper-triangular box matrix with lattice vectors
-            as columns, shape ``(3, 3)``.  ``None`` or an all-zero matrix
-            produces a FREE box.  A 1-D array of shape ``(3,)`` is
-            promoted to a diagonal matrix.
+        matrix: A ``(3, 3)`` upper-triangular box matrix (lattice vectors
+            as columns). ``None`` or an all-zero matrix produces a FREE
+            (non-periodic) box. A ``(3,)`` array is promoted to a
+            diagonal matrix.
         pbc: Boolean periodic-boundary flags per axis, shape ``(3,)``.
-        origin: Cartesian origin of the box in Angstroms, shape ``(3,)``.
+            Defaults to ``[True, True, True]``.
+        origin: Cartesian origin in Angstroms, shape ``(3,)``. Defaults
+            to ``[0, 0, 0]``.
     """
 
     class Style(Enum):
-        """Enumeration of simulation-box geometries.
-
-        Attributes:
-            FREE: No bounding box (vacuum / non-periodic).
-            ORTHOGONAL: Axis-aligned cuboid with three independent edge
-                lengths.
-            TRICLINIC: General parallelepiped described by three edge
-                lengths and three tilt factors (xy, xz, yz).
-        """
+        """Enumeration of simulation-box geometries."""
 
         FREE = 0
         ORTHOGONAL = 1
         TRICLINIC = 2
 
+    # FREE boxes need a non-singular placeholder for the molrs base
+    # (which rejects det(h)==0). The Python-side ``_is_free`` flag
+    # restores zero-volume / zero-matrix semantics for FREE.
+    _PLACEHOLDER_H: np.ndarray = np.eye(3)
+
+    # ────────────────────────────────────────────────────────────────────
+    # construction
+    # ────────────────────────────────────────────────────────────────────
+
+    def __new__(
+        cls,
+        matrix: ArrayLike | None = None,
+        pbc: ArrayLike | None = None,
+        origin: ArrayLike | None = None,
+    ):
+        is_free, h = cls._normalize_matrix(matrix)
+        pbc_arr = cls._normalize_pbc(pbc)
+        origin_arr = cls._normalize_origin(origin)
+        instance = super().__new__(cls, h, origin=origin_arr, pbc=pbc_arr)
+        instance._is_free = is_free
+        return instance
+
     def __init__(
         self,
         matrix: ArrayLike | None = None,
-        pbc: ArrayLike = np.ones(3, dtype=bool),
-        origin: ArrayLike = np.zeros(3),
+        pbc: ArrayLike | None = None,
+        origin: ArrayLike | None = None,
     ):
-        """
-        Initialize a Box object.
+        # State already set by molrs.Box during __new__; nothing to do.
+        # This shim only exists so ``Box(...)`` keyword forwarding to
+        # ``__init__`` does not error.
+        pass
 
-        Parameters:
-            matrix (np.ndarray | None, optional): A 3x3 matrix representing the box dimensions.
-                If None or all elements are zero, a zero matrix is used. If a 1D array of shape (3,)
-                is provided, it is converted to a diagonal matrix. Defaults to None.
-            pbc (np.ndarray, optional): A 1D boolean array of shape (3,) indicating periodic boundary
-                conditions along each axis. Defaults to an array of ones (True for all axes).
-            origin (np.ndarray, optional): A 1D array of shape (3,) representing the origin of the box.
-                Defaults to an array of zeros.
-        """
-        super().__init__()
-        if matrix is None or np.all(matrix == 0):
-            _matrix = np.zeros((3, 3))
-        else:
-            _matrix = np.asarray(matrix)
-            if _matrix.shape == (3,):
-                _matrix = np.diag(_matrix)
-            _matrix = Box.check_matrix(_matrix)
-        self._matrix: np.ndarray = np.array(_matrix, dtype=float)
-        self._pbc: np.ndarray = np.array(pbc, dtype=bool)
-        self._origin: np.ndarray = np.array(origin, dtype=float)
+    @classmethod
+    def _normalize_matrix(cls, matrix: ArrayLike | None) -> tuple[bool, np.ndarray]:
+        if matrix is None:
+            return True, cls._PLACEHOLDER_H.copy()
+        m = np.asarray(matrix, dtype=float)
+        if m.shape == (3,):
+            m = np.diag(m)
+        if m.shape != (3, 3):
+            raise ValueError(f"matrix must be (3, 3) or (3,), got {m.shape}")
+        if np.allclose(m, 0.0):
+            return True, cls._PLACEHOLDER_H.copy()
+        if np.isclose(np.linalg.det(m), 0.0):
+            raise ValueError("matrix must be non-singular")
+        return False, m
+
+    @staticmethod
+    def _normalize_pbc(pbc: ArrayLike | None) -> np.ndarray:
+        if pbc is None:
+            return np.ones(3, dtype=bool)
+        return np.asarray(pbc, dtype=bool).reshape(3)
+
+    @staticmethod
+    def _normalize_origin(origin: ArrayLike | None) -> np.ndarray:
+        if origin is None:
+            return np.zeros(3, dtype=float)
+        return np.asarray(origin, dtype=float).reshape(3)
+
+    # ────────────────────────────────────────────────────────────────────
+    # core read-through accessors (override / shadow molrs)
+    # ────────────────────────────────────────────────────────────────────
+
+    @property
+    def matrix(self) -> np.ndarray:
+        """Box matrix with lattice vectors as columns, shape ``(3, 3)``."""
+        if self._is_free:
+            return np.zeros((3, 3))
+        return np.asarray(self.h)
+
+    @property
+    def style(self) -> "Box.Style":
+        """FREE / ORTHOGONAL / TRICLINIC depending on the matrix shape."""
+        if self._is_free:
+            return Box.Style.FREE
+        return self.calc_style_from_matrix(self.matrix)
+
+    @property
+    def volume(self) -> float:
+        """Box volume in Angstroms³ (zero for FREE)."""
+        if self._is_free:
+            return 0.0
+        return float(np.abs(np.linalg.det(self.matrix)))
+
+    # ── backward-compat private aliases ────────────────────────────────
+    # Internal methods (wrap / diff / make_fractional / transform / …)
+    # still reference ``self._matrix`` / ``self._origin`` / ``self._pbc``
+    # from the original implementation. Expose them as read-only aliases
+    # over the new property-backed accessors.
+
+    @property
+    def _matrix(self) -> np.ndarray:
+        return self.matrix
+
+    @property
+    def _origin(self) -> np.ndarray:
+        return np.asarray(self.origin)
+
+    @property
+    def _pbc(self) -> np.ndarray:
+        return np.asarray(self.pbc)
+
+    # ────────────────────────────────────────────────────────────────────
+    # dunder
+    # ────────────────────────────────────────────────────────────────────
 
     def __repr__(self):
         match self.style:
@@ -91,49 +168,49 @@ class Box(PeriodicBoundary):
         return "<Box>"
 
     def __mul__(self, other: float):
-        _matrix = self._matrix * other
-        return Box(_matrix, self._pbc, self._origin)
+        return Box(self.matrix * other, self._pbc.copy(), self._origin.copy())
 
     def __rmul__(self, other: float):
-        _matrix = self._matrix * other
-        return Box(_matrix, self._pbc, self._origin)
+        return self.__mul__(other)
 
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, Box):
             return False
         return (
-            np.allclose(self._matrix, value.matrix)
-            and np.allclose(self._origin, value.origin)
-            and np.allclose(self._pbc, value.pbc)
+            np.allclose(self.matrix, value.matrix)
+            and np.allclose(self.origin, value.origin)
+            and np.allclose(self.pbc, value.pbc)
         )
 
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __array__(self, dtype=None, copy=None):
+        """``np.array(box)`` → 3x3 box matrix."""
+        m = self.matrix
+        if dtype is not None:
+            m = m.astype(dtype)
+        if copy is True:
+            m = m.copy()
+        return m
+
     def plot(self):
-        """
-        Plot the box representation. This method is a placeholder and should be implemented
-        to visualize the box in 3D space.
-        """
+        """Placeholder for 3D box visualization."""
         ...
+
+    # ────────────────────────────────────────────────────────────────────
+    # factories
+    # ────────────────────────────────────────────────────────────────────
 
     @classmethod
     def cubic(
         cls,
         length: float,
-        pbc: ArrayLike = np.ones(3, dtype=bool),
-        origin: ArrayLike = np.zeros(3),
+        pbc: ArrayLike | None = None,
+        origin: ArrayLike | None = None,
         central: bool = False,
     ) -> "Box":
-        """Create a cubic box with equal edge lengths.
-
-        Args:
-            length: Edge length of the cube in Angstroms.
-            pbc: Periodic boundary flags per axis, shape ``(3,)``.
-            origin: Cartesian origin of the box in Angstroms, shape ``(3,)``.
-            central: If True, shift the origin so the box is centred at
-                the coordinate origin.
-
-        Returns:
-            A new cubic ``Box`` instance.
-        """
+        """Cubic box with three equal edge lengths."""
         if central:
             origin = np.full(3, -length / 2)
         return cls(np.diag(np.full(3, length)), pbc, origin)
@@ -142,25 +219,13 @@ class Box(PeriodicBoundary):
     def orth(
         cls,
         lengths: ArrayLike,
-        pbc: ArrayLike = np.ones(3, dtype=bool),
-        origin: ArrayLike = np.zeros(3),
+        pbc: ArrayLike | None = None,
+        origin: ArrayLike | None = None,
         central: bool = False,
     ) -> "Box":
-        """Create an orthogonal (axis-aligned cuboid) box.
-
-        Args:
-            lengths: Edge lengths ``[lx, ly, lz]`` in Angstroms,
-                shape ``(3,)``.
-            pbc: Periodic boundary flags per axis, shape ``(3,)``.
-            origin: Cartesian origin of the box in Angstroms, shape ``(3,)``.
-            central: If True, shift the origin so the box is centred at
-                the coordinate origin.
-
-        Returns:
-            A new orthogonal ``Box`` instance.
-        """
+        """Orthogonal (axis-aligned cuboid) box."""
         if central:
-            origin = np.zeros(3) - np.asarray(lengths) / 2
+            origin = -np.asarray(lengths) / 2
         return cls(np.diag(lengths), pbc, origin)
 
     @classmethod
@@ -168,66 +233,28 @@ class Box(PeriodicBoundary):
         cls,
         lengths: ArrayLike,
         tilts: ArrayLike,
-        pbc: ArrayLike = np.ones(3, dtype=bool),
-        origin: ArrayLike = np.zeros(3),
+        pbc: ArrayLike | None = None,
+        origin: ArrayLike | None = None,
         central: bool = False,
     ) -> "Box":
-        """Create a triclinic box from edge lengths and tilt factors.
-
-        Args:
-            lengths: Diagonal edge lengths ``[lx, ly, lz]`` in Angstroms,
-                shape ``(3,)``.
-            tilts: Off-diagonal tilt factors ``[xy, xz, yz]`` in Angstroms,
-                shape ``(3,)``.
-            pbc: Periodic boundary flags per axis, shape ``(3,)``.
-            origin: Cartesian origin of the box in Angstroms, shape ``(3,)``.
-            central: If True, shift the origin so the box is centred at
-                the coordinate origin.
-
-        Returns:
-            A new triclinic ``Box`` instance.
-        """
+        """Triclinic box from edge lengths and tilt factors."""
         if central:
             origin = np.asarray(lengths) / 2
         return cls(cls.calc_matrix_from_size_tilts(lengths, tilts), pbc, origin)
 
     @classmethod
     def from_box(cls, box: "Box") -> "Box":
-        """
-        Create a new box from an existing box.
-
-        Args:
-            box (Box): The existing box.
-
-        Returns:
-            Box: A new box with the same properties as the existing box.
-        """
-        return cls(box.matrix.copy(), box.pbc.copy(), box.origin.copy())
+        """Copy constructor."""
+        return cls(box.matrix.copy(), box._pbc.copy(), box._origin.copy())
 
     @classmethod
     def from_bounds(
         cls,
         points: ArrayLike,
         padding: float | ArrayLike = 0.0,
-        pbc: ArrayLike = np.zeros(3, dtype=bool),
+        pbc: ArrayLike | None = None,
     ) -> "Box":
-        """Create an orthogonal box that encloses a set of points.
-
-        Args:
-            points: Point coordinates to enclose, shape ``(N, 3)``.
-            padding: Extra space added to each side of the bounding box,
-                in Angstroms. Either a scalar or a per-axis array of
-                shape ``(3,)``.
-            pbc: Periodic boundary flags per axis, shape ``(3,)``.
-                Defaults to non-periodic.
-
-        Returns:
-            A new orthogonal ``Box`` whose matrix and origin tightly fit
-            ``points`` with ``padding`` added on every side.
-
-        Raises:
-            ValueError: If ``points`` is empty or not ``(N, 3)``.
-        """
+        """Tight orthogonal box around a point cloud (non-periodic by default)."""
         coords = np.asarray(points, dtype=float)
         if coords.ndim != 2 or coords.shape[1] != 3:
             raise ValueError(f"points must have shape (N, 3), got {coords.shape}")
@@ -237,433 +264,164 @@ class Box(PeriodicBoundary):
         pad = np.broadcast_to(np.asarray(padding, dtype=float), (3,))
         mins = coords.min(axis=0) - pad
         maxs = coords.max(axis=0) + pad
+        if pbc is None:
+            pbc = np.zeros(3, dtype=bool)
         return cls(np.diag(maxs - mins), pbc=pbc, origin=mins)
+
+    @classmethod
+    def from_lengths_angles(cls, lengths: ArrayLike, angles: ArrayLike) -> "Box":
+        """Triclinic box from edge lengths and lattice angles (degrees)."""
+        return cls(cls.calc_matrix_from_lengths_angles(lengths, angles))
+
+    def to_lengths_angles(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return ``(lengths, angles)``; angles in degrees."""
+        return self.calc_lengths_angles_from_matrix(self.matrix)
+
+    # ────────────────────────────────────────────────────────────────────
+    # bounds (xlo / xhi / … / bounds)
+    # ────────────────────────────────────────────────────────────────────
 
     @property
     def xlo(self) -> float:
-        """
-        Calculate the lower bound of the box along the x-axis.
-
-        Returns:
-            float: The x-coordinate of the lower bound, calculated as the
-            negative of the x-component of the origin.
-        """
-        return self._origin[0]
+        return float(self._origin[0])
 
     @property
     def xhi(self) -> float:
-        """
-        Calculate the upper boundary of the box along the x-axis.
-
-        Returns:
-            float: The x-coordinate of the upper boundary of the box,
-            calculated as the difference between the first element of
-            the matrix's first row and the x-coordinate of the origin.
-        """
-        return self._matrix[0, 0] - self._origin[0]
+        return float(self._matrix[0, 0] - self._origin[0])
 
     @property
     def ylo(self) -> float:
-        """
-        Get the lower boundary of the box along the y-axis.
-
-        Returns:
-            float: The negative value of the y-coordinate of the origin.
-        """
-        return self._origin[1]
+        return float(self._origin[1])
 
     @property
     def yhi(self) -> float:
-        """
-        Calculate the upper boundary of the box along the y-axis.
-
-        Returns:
-            float: The upper boundary value of the box in the y-dimension,
-            calculated as the difference between the y-component of the
-            matrix and the y-component of the origin.
-        """
-        return self._matrix[1, 1] - self._origin[1]
+        return float(self._matrix[1, 1] - self._origin[1])
 
     @property
     def zlo(self) -> float:
-        """
-        Calculate the lower boundary of the box along the z-axis.
-
-        Returns:
-            float: The z-coordinate of the lower boundary, calculated as the
-            negative value of the third component of the origin vector.
-        """
-        return self._origin[2]
+        return float(self._origin[2])
 
     @property
     def zhi(self) -> float:
-        """
-        Calculate the z-component of the box's upper boundary.
-
-        Returns:
-            float: The z-coordinate of the upper boundary, calculated as the
-            difference between the z-component of the matrix and the z-component
-            of the origin.
-        """
-        return self._matrix[2, 2] - self._origin[2]
+        return float(self._matrix[2, 2] - self._origin[2])
 
     @property
     def bounds(self) -> np.ndarray:
-        """
-        Get the bounds of the box.
-
-        Returns:
-            np.ndarray: A 2D array with shape (3, 2) representing the bounds of the box.
-        """
         return np.array(
             [[self.xlo, self.xhi], [self.ylo, self.yhi], [self.zlo, self.zhi]]
         ).T
 
-    @property
-    def style(self) -> Style:
-        """
-        Determine the style of the box based on its matrix.
-
-        Returns:
-            Style: The style of the box (FREE, ORTHOGONAL, or TRICLINIC).
-        """
-        return self.calc_style_from_matrix(self._matrix)
-
-    @property
-    def pbc(self) -> np.ndarray:
-        """
-        Get the periodic boundary conditions of the box.
-
-        Returns:
-            np.ndarray: A boolean array indicating periodicity along each axis.
-        """
-        return self._pbc
-
-    @property
-    def matrix(self) -> np.ndarray:
-        """
-        Get the matrix representation of the box.
-
-        Returns:
-            np.ndarray: A 3x3 matrix representing the box dimensions.
-        """
-        return self._matrix
-
-    def __array__(self, dtype=None, copy=None):
-        """Allow Box to be converted to numpy array (returns 3x3 matrix).
-
-        This enables np.array(box) to automatically convert Box to its matrix
-        representation, which is useful for serialization and numerical operations.
-
-        Args:
-            dtype: Optional numpy dtype for the array.
-            copy: Optional copy flag (for numpy 2.0+ compatibility).
-
-        Returns:
-            np.ndarray: The 3x3 box matrix.
-        """
-        matrix = self._matrix
-        if dtype is not None:
-            matrix = matrix.astype(dtype)
-        if copy is True:
-            matrix = matrix.copy()
-        return matrix
-
-    @property
-    def volume(self) -> float:
-        """
-        Calculate the volume of the box.
-
-        Returns:
-            float: The volume of the box.
-        """
-        return np.abs(np.linalg.det(self._matrix))
-
-    @property
-    def origin(self) -> np.ndarray:
-        """Cartesian origin of the box in Angstroms.
-
-        Returns:
-            np.ndarray: Origin coordinates, shape ``(3,)``.
-        """
-        return self._origin
-
-    @origin.setter
-    def origin(self, value: np.ndarray):
-        value = np.asarray(value)
-        assert value.shape == (3,), "origin must be (3,)"
-        self._origin = value
+    # ────────────────────────────────────────────────────────────────────
+    # diagonal / off-diagonal accessors
+    # ────────────────────────────────────────────────────────────────────
 
     @property
     def lx(self) -> float:
-        """
-        Get the length of the box along the x-axis.
-
-        Returns:
-            float: The length of the box in the x-direction, derived from the
-            first element of the matrix representing the box dimensions.
-        """
-        return self._matrix[0, 0]
-
-    @lx.setter
-    def lx(self, value: float):
-        self._matrix[0, 0] = value
+        return float(self._matrix[0, 0])
 
     @property
     def ly(self) -> float:
-        """
-        Get the length of the simulation box along the y-axis.
-
-        Returns:
-            float: The length of the box in the y-direction.
-        """
-        return self._matrix[1, 1]
-
-    @ly.setter
-    def ly(self, value: float):
-        self._matrix[1, 1] = value
+        return float(self._matrix[1, 1])
 
     @property
     def lz(self) -> float:
-        """
-        Get the length of the simulation box along the z-axis.
-
-        Returns:
-            float: The length of the box in the z-direction.
-        """
-        return self._matrix[2, 2]
-
-    @lz.setter
-    def lz(self, value: float):
-        self._matrix[2, 2] = value
+        return float(self._matrix[2, 2])
 
     @property
     def l(self) -> np.ndarray:
-        """
-        Get the lengths of the box along each axis.
-
-        Returns:
-            np.ndarray: A 1D array containing the lengths of the box along
-            the x, y, and z axes.
-        """
-        return self._matrix.diagonal()
+        return self._matrix.diagonal().copy()
 
     @property
     def l_inv(self) -> np.ndarray:
-        """Reciprocal of the box edge lengths in inverse Angstroms.
-
-        Returns:
-            np.ndarray: ``1 / [lx, ly, lz]``, shape ``(3,)``.
-        """
-        return 1 / self.l
+        l = self.l
+        with np.errstate(divide="ignore"):
+            return np.where(l != 0.0, 1.0 / np.where(l == 0.0, 1.0, l), 0.0)
 
     @property
     def xy(self) -> float:
-        """
-        Retrieve the xy component of the matrix.
-
-        Returns:
-            float: The value at the (0, 1) position in the matrix.
-        """
-        return self._matrix[0, 1]
-
-    @xy.setter
-    def xy(self, value: float):
-        self._matrix[0, 1] = value
+        return float(self._matrix[0, 1])
 
     @property
     def xz(self) -> float:
-        """Tilt factor between the x and z axes in Angstroms.
-
-        Returns:
-            float: The ``(0, 2)`` element of the box matrix.
-        """
-        return self._matrix[0, 2]
-
-    @xz.setter
-    def xz(self, value: float):
-        self._matrix[0, 2] = value
+        return float(self._matrix[0, 2])
 
     @property
     def yz(self) -> float:
-        """Tilt factor between the y and z axes in Angstroms.
-
-        Returns:
-            float: The ``(1, 2)`` element of the box matrix.
-        """
-        return self._matrix[1, 2]
-
-    @yz.setter
-    def yz(self, value: float):
-        self._matrix[1, 2] = value
+        return float(self._matrix[1, 2])
 
     @property
     def a(self) -> np.ndarray:
-        """First lattice vector of the box in Angstroms.
-
-        Returns:
-            np.ndarray: Column 0 of the box matrix, shape ``(3,)``.
-        """
-        return self._matrix[:, 0]
+        return self._matrix[:, 0].copy()
 
     @property
     def b(self) -> np.ndarray:
-        """Second lattice vector of the box in Angstroms.
-
-        Returns:
-            np.ndarray: Column 1 of the box matrix, shape ``(3,)``.
-        """
-        return self._matrix[:, 1]
+        return self._matrix[:, 1].copy()
 
     @property
     def c(self) -> np.ndarray:
-        """Third lattice vector of the box in Angstroms.
-
-        Returns:
-            np.ndarray: Column 2 of the box matrix, shape ``(3,)``.
-        """
-        return self._matrix[:, 2]
-
-    @property
-    def periodic(self) -> bool:
-        """Whether the box is periodic in all three directions.
-
-        Returns:
-            bool: True if periodic boundary conditions are active along
-            every axis.
-        """
-        return bool(self._pbc.all())
-
-    @periodic.setter
-    def periodic(self, value: bool | list[bool]):
-        if isinstance(value, list):
-            assert len(value) == 3, "value must be list of length 3"
-            self._pbc = np.array(value, dtype=bool)
-        else:
-            self._pbc = np.full(3, value, dtype=bool)
-
-    @property
-    def periodic_x(self) -> bool:
-        """Whether the box is periodic along the x-axis.
-
-        Returns:
-            bool: True if periodic in x.
-        """
-        return self._pbc[0]
-
-    @periodic_x.setter
-    def periodic_x(self, value: bool):
-        self._pbc[0] = value
-
-    @property
-    def periodic_y(self) -> bool:
-        """Whether the box is periodic along the y-axis.
-
-        Returns:
-            bool: True if periodic in y.
-        """
-        return self._pbc[1]
-
-    @periodic_y.setter
-    def periodic_y(self, value: bool):
-        self._pbc[1] = value
-
-    @property
-    def periodic_z(self) -> bool:
-        """Whether the box is periodic along the z-axis.
-
-        Returns:
-            bool: True if periodic in z.
-        """
-        return self._pbc[2]
-
-    @periodic_z.setter
-    def periodic_z(self, value: bool):
-        self._pbc[2] = value
+        return self._matrix[:, 2].copy()
 
     @property
     def tilts(self) -> np.ndarray:
-        """Off-diagonal tilt factors of the box matrix in Angstroms.
-
-        Returns:
-            np.ndarray: ``[xy, xz, yz]``, shape ``(3,)``.
-        """
         return np.array([self.xy, self.xz, self.yz])
+
+    # ────────────────────────────────────────────────────────────────────
+    # PBC flags
+    # ────────────────────────────────────────────────────────────────────
+
+    @property
+    def periodic(self) -> bool:
+        return bool(self._pbc.all())
+
+    @property
+    def periodic_x(self) -> bool:
+        return bool(self._pbc[0])
+
+    @property
+    def periodic_y(self) -> bool:
+        return bool(self._pbc[1])
+
+    @property
+    def periodic_z(self) -> bool:
+        return bool(self._pbc[2])
 
     @property
     def is_periodic(self) -> bool:
-        """Check if the box has periodic boundary conditions in all directions."""
         return self.periodic
 
-    @staticmethod
-    def check_matrix(matrix: np.ndarray) -> np.ndarray:
-        """
-        Validate the box matrix.
-
-        Args:
-            matrix (np.ndarray): A 3x3 matrix to validate.
-
-        Returns:
-            np.ndarray: The validated matrix.
-
-        Raises:
-            AssertionError: If the matrix is not valid.
-        """
-        assert isinstance(matrix, np.ndarray), "matrix must be np.ndarray"
-        assert matrix.shape == (3, 3), "matrix must be (3, 3)"
-        assert not np.isclose(np.linalg.det(matrix), 0), "matrix must be non-singular"
-        return matrix
+    # ────────────────────────────────────────────────────────────────────
+    # lengths / angles
+    # ────────────────────────────────────────────────────────────────────
 
     @property
     def lengths(self) -> np.ndarray:
         """Lattice vector magnitudes ``[a, b, c]`` in Angstroms.
 
-        For a FREE box all lengths are zero.  For orthogonal and triclinic
-        boxes the lengths are computed from the box matrix.
-
-        Returns:
-            np.ndarray: Edge lengths, shape ``(3,)``.
+        Returns zeros for FREE.
         """
-        match self.style:
-            case Box.Style.FREE:
-                return np.zeros(3)
-            case Box.Style.ORTHOGONAL | Box.Style.TRICLINIC:
-                return self.calc_lengths_angles_from_matrix(self._matrix)[0]
-        raise ValueError("Invalid box style")
-
-    @lengths.setter
-    def lengths(self, value: np.ndarray):
-        value = np.asarray(value)
-        assert value.shape == (3,), ValueError("lengths must be (3,)")
-        matrix = self.calc_matrix_from_lengths_angles(value, self.angles)
-        self._matrix = matrix
+        if self._is_free:
+            return np.zeros(3)
+        return self.calc_lengths_angles_from_matrix(self.matrix)[0]
 
     @property
     def angles(self) -> np.ndarray:
-        """Lattice angles ``[alpha, beta, gamma]`` in degrees.
+        """Lattice angles ``[alpha, beta, gamma]`` in degrees."""
+        return self.calc_lengths_angles_from_matrix(self.matrix)[1]
 
-        Alpha is the angle between lattice vectors **b** and **c**, beta
-        between **a** and **c**, and gamma between **a** and **b**.
+    # ────────────────────────────────────────────────────────────────────
+    # static helpers
+    # ────────────────────────────────────────────────────────────────────
 
-        Returns:
-            np.ndarray: Angles in degrees, shape ``(3,)``.
-        """
-        return self.calc_lengths_angles_from_matrix(self._matrix)[1]
+    @staticmethod
+    def check_matrix(matrix: np.ndarray) -> np.ndarray:
+        assert isinstance(matrix, np.ndarray), "matrix must be np.ndarray"
+        assert matrix.shape == (3, 3), "matrix must be (3, 3)"
+        assert not np.isclose(np.linalg.det(matrix), 0), "matrix must be non-singular"
+        return matrix
 
     @staticmethod
     def general2restrict(matrix: np.ndarray) -> np.ndarray:
-        """
-        Convert general triclinc box matrix to restricted triclinic box matrix
-
-        Ref:
-            https://docs.lammps.org/Howto_triclinic.html#transformation-from-general-to-restricted-triclinic-boxes
-
-        Args:
-            matrix (np.ndarray): (3, 3) general triclinc box matrix
-
-        Returns:
-            np.ndarray: (3, 3) restricted triclinc box matrix
-        """
+        """General → restricted-triclinic conversion (LAMMPS convention)."""
         A = matrix[:, 0]
         B = matrix[:, 1]
         C = matrix[:, 2]
@@ -676,63 +434,21 @@ class Box(PeriodicBoundary):
         uAxB = AxB / np.linalg.norm(AxB)
         cy = np.dot(C, np.cross(uAxB, uA))
         cz = np.dot(C, uAxB)
-        # validation code
-        # import numpy.testing as npt
-        # gamma = np.arccos(np.dot(A, C) / np.linalg.norm(A) / np.linalg.norm(C))
-        # beta = np.arccos(np.dot(A, B) / np.linalg.norm(A) / np.linalg.norm(B))
-        # npt.assert_allclose(
-        #     bx,
-        #     np.linalg.norm(B) * np.cos(gamma),
-        #     err_msg=f"{bx} != {np.linalg.norm(B) * np.cos(gamma)}",
-        # )
-        # npt.assert_allclose(
-        #     by,
-        #     np.linalg.norm(B) * np.sin(gamma),
-        #     err_msg=f"{by} != {np.linalg.norm(B) * np.sin(gamma)}",
-        # )
-        # npt.assert_allclose(
-        #     cx,
-        #     np.linalg.norm(C) * np.cos(beta),
-        #     err_msg=f"{cx} != {np.linalg.norm(C) * np.cos(beta)}",
-        # )
-        # npt.assert_allclose(
-        #     cy,
-        #     (np.dot(B, C) - bx * cx) / by,
-        #     err_msg=f"{cy} != {(np.dot(B, C) - bx * cx) / by}",
-        # )
-        # npt.assert_allclose(
-        #     cz,
-        #     np.sqrt(np.linalg.norm(C) ** 2 - cx**2 - cy**2),
-        #     err_msg=f"{cz} != {np.sqrt(np.linalg.norm(C) ** 2 - cx ** 2 - cy ** 2)}",
-        # )
-        # TODO: extract origin and direction
         return np.array([[ax, bx, cx], [0, by, cy], [0, 0, cz]])
 
     @staticmethod
     def calc_matrix_from_lengths_angles(
         abc: ArrayLike, angles: ArrayLike
     ) -> np.ndarray:
-        """
-        Compute restricted triclinic box matrix from lengths and angles.
-
-        Args:
-            abc (np.ndarray): [a, b, c] lattice vector lengths
-            angles (np.ndarray): [alpha, beta, gamma] in degrees (angles between (b,c), (a,c), (a,b))
-
-        Returns:
-            np.ndarray: 3x3 box matrix with lattice vectors as columns: [a | b | c]
-        """
         a, b, c = abc
         angles = alpha, beta, gamma = np.deg2rad(angles)
         cos_a, cos_b, cos_c = np.cos(angles)
 
-        # Optional: volume sanity check
         cos_check = cos_a**2 + cos_b**2 + cos_c**2 - 2 * cos_a * cos_b * cos_c
         if cos_check >= 1.0:
             raise ValueError(
                 f"Invalid box: angles produce non-physical volume. abc={abc}, angles={angles}"
             )
-
         if not (0 < alpha < np.pi):
             raise ValueError("alpha must be in (0, 180)")
         if not (0 < beta < np.pi):
@@ -740,7 +456,6 @@ class Box(PeriodicBoundary):
         if not (0 < gamma < np.pi):
             raise ValueError("gamma must be in (0, 180)")
 
-        # Construct box
         lx = a
         xy = b * cos_c
         xz = c * cos_b
@@ -748,21 +463,10 @@ class Box(PeriodicBoundary):
         yz = (b * c * cos_a - xy * xz) / ly
         tmp = c**2 - xz**2 - yz**2
         lz = np.sqrt(tmp)
-
         return np.array([[lx, xy, xz], [0.0, ly, yz], [0.0, 0.0, lz]])
 
     @staticmethod
     def calc_matrix_from_size_tilts(sizes, tilts) -> np.ndarray:
-        """
-        Get restricted triclinic box matrix from sizes and tilts
-
-        Args:
-            sizes (np.ndarray): sizes of box edges
-            tilts (np.ndarray): tilts between box edges
-
-        Returns:
-            np.ndarray: restricted triclinic box matrix
-        """
         lx, ly, lz = sizes
         xy, xz, yz = tilts
         return np.array([[lx, xy, xz], [0, ly, yz], [0, 0, lz]])
@@ -771,16 +475,6 @@ class Box(PeriodicBoundary):
     def calc_lengths_angles_from_matrix(
         matrix: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Calculate the lengths of the box edges and angles from its matrix.
-
-        Args:
-            matrix (np.ndarray): A 3x3 matrix representing the box.
-
-        Returns:
-            tuple[np.ndarray, np.ndarray]: lengths and angles
-        """
-
         lx = matrix[0, 0]
         ly = matrix[1, 1]
         lz = matrix[2, 2]
@@ -797,19 +491,7 @@ class Box(PeriodicBoundary):
         return np.array([a, b, c]), np.rad2deg(np.arccos([cos_a, cos_b, cos_c]))
 
     @staticmethod
-    def calc_style_from_matrix(matrix: np.ndarray) -> Style:
-        """
-        Determine the style of the box based on its matrix.
-
-        Args:
-            matrix (np.ndarray): A 3x3 matrix representing the box.
-
-        Returns:
-            Style: The style of the box (FREE, ORTHOGONAL, or TRICLINIC).
-
-        Raises:
-            ValueError: If the matrix does not correspond to a valid style.
-        """
+    def calc_style_from_matrix(matrix: np.ndarray) -> "Box.Style":
         if np.allclose(matrix, np.zeros(3)):
             return Box.Style.FREE
         elif np.allclose(matrix, np.diag(np.diagonal(matrix))):
@@ -821,87 +503,11 @@ class Box(PeriodicBoundary):
         else:
             raise ValueError("Invalid box matrix")
 
-    @classmethod
-    def from_lengths_angles(cls, lengths: ArrayLike, angles: ArrayLike) -> "Box":
-        """
-        Get box matrix from lengths and angles
-
-        Args:
-            lengths (np.ndarray): lengths of box edges
-            angles (np.ndarray): angles between box edges in degree
-
-        Returns:
-            Box: Box instance constructed from lengths and angles.
-        """
-        return cls(cls.calc_matrix_from_lengths_angles(lengths, angles))
-
-    def to_lengths_angles(self) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Get lengths and angles from box matrix
-
-        Returns:
-            tuple[np.ndarray, np.ndarray]: lengths and angles
-        """
-        return self.calc_lengths_angles_from_matrix(self._matrix)
-
-    def set_lengths(self, lengths: np.ndarray):
-        """Set the lattice vector magnitudes, preserving current angles.
-
-        Args:
-            lengths: New edge lengths ``[a, b, c]`` in Angstroms,
-                shape ``(3,)``.
-        """
-        self._matrix = self.calc_matrix_from_lengths_angles(lengths, self.angles)
-
-    def set_angles(self, angles: np.ndarray):
-        """Set the lattice angles, preserving current edge lengths.
-
-        Args:
-            angles: New angles ``[alpha, beta, gamma]`` in degrees,
-                shape ``(3,)``.
-        """
-        self._matrix = self.calc_matrix_from_lengths_angles(self.lengths, angles)
-
-    def set_matrix(self, matrix: np.ndarray):
-        """Replace the box matrix directly.
-
-        Args:
-            matrix: New 3x3 upper-triangular box matrix, shape ``(3, 3)``.
-        """
-        self._matrix = matrix
-
-    def set_lengths_angles(self, lengths: np.ndarray, angles: np.ndarray):
-        """Set both edge lengths and lattice angles simultaneously.
-
-        Args:
-            lengths: Edge lengths ``[a, b, c]`` in Angstroms, shape ``(3,)``.
-            angles: Angles ``[alpha, beta, gamma]`` in degrees, shape ``(3,)``.
-        """
-        self._matrix = self.calc_matrix_from_lengths_angles(lengths, angles)
-
-    def set_lengths_tilts(self, lengths: np.ndarray, tilts: np.ndarray):
-        """Set edge lengths and tilt factors simultaneously.
-
-        Args:
-            lengths: Diagonal edge lengths ``[lx, ly, lz]`` in Angstroms,
-                shape ``(3,)``.
-            tilts: Off-diagonal tilt factors ``[xy, xz, yz]`` in Angstroms,
-                shape ``(3,)``.
-        """
-        self._matrix = self.calc_matrix_from_size_tilts(lengths, tilts)
+    # ────────────────────────────────────────────────────────────────────
+    # geometry — face distances, wrap, unwrap, diff, dist, fractional
+    # ────────────────────────────────────────────────────────────────────
 
     def get_distance_between_faces(self) -> np.ndarray:
-        """Perpendicular distances between opposite faces in Angstroms.
-
-        For an orthogonal box these equal the edge lengths.  For a
-        triclinic box the distances are computed by projecting each
-        lattice vector onto the normal of the plane spanned by the other
-        two vectors.
-
-        Returns:
-            np.ndarray: Distances ``[d_x, d_y, d_z]`` in Angstroms,
-                shape ``(3,)``.  All zeros for a FREE box.
-        """
         match self.style:
             case Box.Style.FREE:
                 return np.zeros(3)
@@ -911,30 +517,15 @@ class Box(PeriodicBoundary):
                 a = self._matrix[:, 0]
                 b = self._matrix[:, 1]
                 c = self._matrix[:, 2]
-
                 na = np.cross(b, c)
                 nb = np.cross(c, a)
                 nc = np.cross(a, b)
                 na /= np.linalg.norm(na)
                 nb /= np.linalg.norm(nb)
                 nc /= np.linalg.norm(nc)
-
                 return np.array([np.dot(na, a), np.dot(nb, b), np.dot(nc, c)])
 
     def wrap(self, xyz: np.ndarray) -> np.ndarray:
-        """Wrap Cartesian coordinates into the primary image of the box.
-
-        Delegates to style-specific implementations (free, orthogonal,
-        or triclinic).
-
-        Args:
-            xyz: Cartesian positions in Angstroms, shape ``(N, 3)`` or
-                ``(3,)``.
-
-        Returns:
-            np.ndarray: Wrapped coordinates with the same shape as the
-                input, in Angstroms.
-        """
         xyz = np.asarray(xyz)
         match self.style:
             case Box.Style.FREE:
@@ -948,85 +539,29 @@ class Box(PeriodicBoundary):
         return wrapped
 
     def wrap_free(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Wrap coordinates for a free box style.
-
-        Args:
-            xyz (np.ndarray): The coordinates to wrap.
-
-        Returns:
-            np.ndarray: The wrapped coordinates.
-        """
         return xyz
 
     def wrap_orthogonal(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Wrap coordinates for an orthogonal box style.
-
-        Args:
-            xyz (np.ndarray): The coordinates to wrap.
-
-        Returns:
-            np.ndarray: The wrapped coordinates.
-        """
-        lengths = self.lengths  # Should be shape (3,)
+        lengths = self.lengths
         return xyz - np.floor(xyz / lengths) * lengths
 
     def wrap_triclinic(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Wrap coordinates for a triclinic box style.
-
-        Args:
-            xyz (np.ndarray): The coordinates to wrap.
-
-        Returns:
-            np.ndarray: The wrapped coordinates.
-        """
-        xyz = np.atleast_2d(xyz)  # Ensure xyz is a 2D array
+        xyz = np.atleast_2d(xyz)
         frac = self.make_fractional(xyz)
         frac_wrapped = frac - np.floor(frac)
         return self.make_absolute(frac_wrapped)
 
     def unwrap(self, xyz: np.ndarray, image: np.ndarray) -> np.ndarray:
-        """
-        Unwrap the coordinates of a particle based on its image.
-
-        Args:
-            xyz (np.ndarray): The coordinates of the particle.
-            image (np.ndarray): The image of the particle.
-
-        Returns:
-            np.ndarray: The unwrapped coordinates.
-        """
         return xyz + image @ self._matrix.T
 
     def get_images(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Get the image flags of particles, accounting for box origin and triclinic shape.
-        """
         fractional = self.make_fractional(xyz)
-        # Add small epsilon to avoid numerical floor error at box edges
         return np.floor(fractional + 1e-8).astype(int)
 
     def get_inv(self) -> np.ndarray:
-        """
-        Get the inverse of the box matrix.
-
-        Returns:
-            np.ndarray: The inverse of the box matrix.
-        """
         return np.linalg.inv(self._matrix)
 
     def diff_dr(self, dr: np.ndarray) -> np.ndarray:
-        """
-        Calculate the difference vector considering periodic boundary conditions.
-
-        Args:
-            dr (np.ndarray): The difference vector.
-
-        Returns:
-            np.ndarray: The adjusted difference vector.
-        """
         match self.style:
             case Box.Style.FREE:
                 return dr
@@ -1036,29 +571,9 @@ class Box(PeriodicBoundary):
                 return np.dot(self._matrix, fractional.T).T
 
     def diff(self, r1: np.ndarray, r2: np.ndarray) -> np.ndarray:
-        """
-        Calculate the difference between two points considering periodic boundary conditions.
-
-        Args:
-            r1 (np.ndarray): The first point.
-            r2 (np.ndarray): The second point.
-
-        Returns:
-            np.ndarray: The difference vector.
-        """
         return self.diff_dr(r1 - r2)
 
     def diff_all(self, r1: np.ndarray, r2: np.ndarray) -> np.ndarray:
-        """
-        Calculate the difference between all pairs of points in two sets.
-
-        Args:
-            r1 (np.ndarray): The first set of points.
-            r2 (np.ndarray): The second set of points.
-
-        Returns:
-            np.ndarray: The difference vectors for all pairs.
-        """
         all_dr = r1[:, np.newaxis, :] - r2[np.newaxis, :, :]
         original_shape = all_dr.shape
         all_dr = all_dr.reshape(-1, 3)
@@ -1067,103 +582,32 @@ class Box(PeriodicBoundary):
         return all_dr
 
     def dist(self, r1: np.ndarray, r2: np.ndarray) -> np.ndarray:
-        """
-        Calculate the distance between two points.
-
-        Args:
-            r1 (np.ndarray): The first point.
-            r2 (np.ndarray): The second point.
-
-        Returns:
-            np.ndarray: The distance between the points.
-        """
         dr = self.diff(r1, r2)
         return np.linalg.norm(dr, axis=1)
 
     def dist_all(self, r1: np.ndarray, r2: np.ndarray) -> np.ndarray:
-        """
-        Calculate the distances between all pairs of points in two sets.
-
-        Args:
-            r1 (np.ndarray): The first set of points.
-            r2 (np.ndarray): The second set of points.
-
-        Returns:
-            np.ndarray: The distances for all pairs.
-        """
         dr = self.diff_all(r1, r2)
         return np.linalg.norm(dr, axis=-1)
 
     def make_fractional(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Convert absolute coordinates to fractional coordinates.
-
-        Args:
-            xyz (np.ndarray): The absolute coordinates.
-
-        Returns:
-            np.ndarray: The fractional coordinates.
-        """
         return (xyz - self._origin) @ self.get_inv().T
 
     def make_absolute(self, xyz: np.ndarray) -> np.ndarray:
-        """
-        Convert fractional coordinates to absolute coordinates.
-
-        Args:
-            xyz (np.ndarray): The fractional coordinates.
-
-        Returns:
-            np.ndarray: The absolute coordinates.
-        """
         return xyz @ self._matrix.T + self._origin
 
     def isin(self, xyz: np.ndarray):
-        """
-        Check if point(s) xyz are inside the box.
-        Args:
-            xyz (np.ndarray): shape (..., 3)
-        Returns:
-            np.ndarray: boolean array, True if inside
-        """
         xyz = np.asarray(xyz)
         fractional = self.make_fractional(xyz)
         return np.all((fractional >= 0) & (fractional < 1), axis=-1)
 
     def merge(self, other: "Box") -> "Box":
-        """
-        Merge two boxes to find their common space.
-
-        Args:
-            other (Box): The other box to merge with.
-
-        Returns:
-            Box: A new box representing the common space.
-        """
         return Box(matrix=other.matrix)
 
     def transform(self, transformation_matrix: np.ndarray) -> "Box":
-        """Transform the box using a transformation matrix.
-
-        Args:
-            transformation_matrix: 3x3 transformation matrix.
-
-        Returns:
-            New Box with transformed dimensions.
-        """
-        # Transform the box matrix
         new_matrix = self._matrix @ transformation_matrix
-
-        # Keep the same periodic boundary conditions and origin
         return Box(matrix=new_matrix, pbc=self._pbc.copy(), origin=self._origin.copy())
 
     def to_dict(self) -> dict:
-        """
-        Convert the box to a dictionary representation.
-
-        Returns:
-            dict: A dictionary containing the box properties.
-        """
         return {
             "matrix": self._matrix.tolist(),
             "pbc": self._pbc.tolist(),

--- a/src/molpy/core/cg.py
+++ b/src/molpy/core/cg.py
@@ -1,9 +1,22 @@
+"""Coarse-grained molecular structure.
+
+Mirrors :mod:`molpy.core.atomistic` in shape and contract; see
+:doc:`../specs/cg-atomistic-mapping-redesign` for the design rationale.
+
+Conventional dict keys (none enforced):
+
+* ``bead["atoms"]`` — ``tuple[Atom, ...]`` of atom references this bead
+  represents (when projected from an :class:`Atomistic`). Required only by
+  :meth:`CoarseGrain.beads_of`.
+* ``bead["x"]``, ``bead["y"]``, ``bead["z"]`` — primary position; consumed by
+  :class:`SpatialMixin` for ``move`` / ``rotate`` / ``scale`` / ``align``.
+* ``bead["type"]``, ``bead["mass"]``, ``bead["charge"]`` — as needed.
+"""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
-
-if TYPE_CHECKING:
-    from .atomistic import Atomistic
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from .entity import (
     ConnectivityMixin,
@@ -15,38 +28,21 @@ from .entity import (
     Struct,
 )
 
+if TYPE_CHECKING:
+    from .atomistic import Atom
+    from .frame import Frame
+
 
 class Bead(Entity):
-    """Coarse-grain bead entity.
+    """Coarse-grained bead.
 
-    A bead can optionally map to an Atomistic structure via the atomistic member.
-    Supports arbitrary attributes via dictionary interface.
+    Structurally identical to :class:`~molpy.core.atomistic.Atom`: a dict-like
+    :class:`Entity` with no mandatory fields. All bead state lives in the
+    underlying dict.
 
-    Attributes:
-        atomistic: Optional reference to an Atomistic structure this bead represents
+    See module docstring for the optional convention keys recognised by
+    :class:`CoarseGrain` and the spatial mixin.
     """
-
-    def __init__(
-        self, data_dict=None, /, atomistic: "Atomistic | None" = None, **attrs: Any
-    ):
-        # Handle being called with just a dict (for copy compatibility)
-        if data_dict is not None and isinstance(data_dict, dict):
-            super().__init__(**data_dict)
-            self.atomistic = None  # Will be set by __deepcopy__ if needed
-        else:
-            # Normal creation: data_dict is actually atomistic or None
-            if data_dict is not None:
-                atomistic = data_dict
-            super().__init__(**attrs)
-            self.atomistic = atomistic
-
-    def __deepcopy__(self, memo):
-        """Custom deep copy to handle atomistic member."""
-        from copy import deepcopy
-
-        # Create new bead with copied data and atomistic reference (not copy)
-        new_bead = Bead(atomistic=self.atomistic, **deepcopy(self.data, memo))
-        return new_bead
 
     def __repr__(self) -> str:
         identifier: str
@@ -60,11 +56,25 @@ class Bead(Entity):
 
 
 class CGBond(Link):
-    """Coarse-grained bond connecting two beads."""
+    """Coarse-grained bond between two beads.
 
-    def __init__(self, a: Bead, b: Bead, /, **attrs: Any):
-        assert isinstance(a, Bead), f"bead a must be a Bead instance, got {type(a)}"
-        assert isinstance(b, Bead), f"bead b must be a Bead instance, got {type(b)}"
+    Parallel to :class:`~molpy.core.atomistic.Bond`: a :class:`Link` carrying
+    two :class:`Bead` endpoints plus arbitrary attributes.
+    """
+
+    def __init__(self, a: Bead, b: Bead, /, **attrs: Any) -> None:
+        """Initialise a CG bond between two beads.
+
+        Args:
+            a: First bead endpoint.
+            b: Second bead endpoint.
+            **attrs: Additional bond attributes.
+
+        Raises:
+            AssertionError: If ``a`` or ``b`` is not a :class:`Bead` instance.
+        """
+        assert isinstance(a, Bead), f"a must be Bead, got {type(a)}"
+        assert isinstance(b, Bead), f"b must be Bead, got {type(b)}"
         super().__init__([a, b], **attrs)
 
     def __repr__(self) -> str:
@@ -82,17 +92,29 @@ class CGBond(Link):
 
 
 class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
-    """Coarse-grained molecular structure container.
+    """Coarse-grained molecular structure.
 
-    Similar to Atomistic but for coarse-grained representations using Beads and CGBonds.
-    Supports bidirectional conversion with Atomistic structures.
+    Public surface mirrors :class:`~molpy.core.atomistic.Atomistic` 1:1
+    except for the single extra method :meth:`beads_of`. The class makes no
+    assumption about the existence, source, or definition of bead positions,
+    masses, or atom-level provenance — those are dict-key conventions
+    documented at module level.
     """
 
-    def __init__(self, **props) -> None:
+    def __init__(self, **props: Any) -> None:
+        """Initialise an empty coarse-grained structure.
+
+        Registers buckets for :class:`Bead` and :class:`CGBond`. If the
+        concrete subclass defines a ``__post_init__`` method, it is called
+        with the same keyword arguments (template pattern, parallel to
+        :class:`Atomistic`).
+
+        Args:
+            **props: Arbitrary properties stored on the structure (e.g.,
+                ``name="POPC"``, ``model="martini3"``).
+        """
         super().__init__(**props)
-        # Call __post_init__ if it exists (for template pattern)
         if hasattr(self, "__post_init__"):
-            # Get the method from the actual class, not from parent
             for klass in type(self).__mro__:
                 if klass is CoarseGrain:
                     break
@@ -104,86 +126,198 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
 
     @property
     def beads(self) -> Entities[Bead]:
-        """Collection of all beads in the structure."""
+        """All beads registered in this structure."""
         return self.entities[Bead]
 
     @property
     def cgbonds(self) -> Entities[CGBond]:  # type: ignore[type-var]
-        """Collection of all CG bonds in the structure."""
+        """All CG bonds registered in this structure."""
         return self.links[CGBond]  # type: ignore[return-value]
 
     def __repr__(self) -> str:
-        """Return a concise representation of the coarse-grained structure."""
-        beads = self.beads
-        cgbonds = self.cgbonds
-
-        # Count beads by type
         from collections import Counter
 
-        types = [b.get("type", "?") for b in beads]
-        type_counts = Counter(types)
-
-        # Format composition
-        if len(type_counts) <= 5:
-            composition = " ".join(
-                f"{typ}:{cnt}" for typ, cnt in sorted(type_counts.items())
-            )
+        types = Counter(b.get("type", "?") for b in self.beads)
+        if len(types) <= 5:
+            comp = " ".join(f"{t}:{n}" for t, n in sorted(types.items()))
         else:
-            composition = f"{len(type_counts)} types"
+            comp = f"{len(types)} types"
+        return (
+            f"<CoarseGrain, {len(self.beads)} beads ({comp}), "
+            f"{len(self.cgbonds)} bonds>"
+        )
 
-        parts = ["CoarseGrain"]
-        parts.append(f"{len(beads)} beads ({composition})")
-        parts.append(f"{len(cgbonds)} bonds")
+    def __len__(self) -> int:
+        """Return the number of beads."""
+        return len(self.beads)
 
-        return f"<{', '.join(parts)}>"
+    # ========== Factory Methods (def_*: create + register) ==========
 
-    # ========== Factory Methods (def_*: create and add) ==========
-
-    def def_bead(self, /, atomistic: "Atomistic | None" = None, **attrs: Any) -> Bead:
-        """Create a new Bead and add it to the structure.
+    def def_bead(self, /, **attrs: Any) -> Bead:
+        """Create a new :class:`Bead` and register it.
 
         Args:
-            atomistic: Optional Atomistic structure this bead represents
-            **attrs: Bead attributes (x, y, z, type, etc.)
+            **attrs: Bead attributes (any keys; see module docstring for
+                conventional keys).
+
+        Returns:
+            The newly registered Bead.
         """
-        bead = Bead(atomistic=atomistic, **attrs)
+        bead = Bead(**attrs)
         self.entities.add(bead)
         return bead
 
     def def_cgbond(self, a: Bead, b: Bead, /, **attrs: Any) -> CGBond:
-        """Create a new CGBond between two beads and add it to the structure."""
+        """Create a new :class:`CGBond` between two beads and register it.
+
+        Args:
+            a: First bead endpoint.
+            b: Second bead endpoint.
+            **attrs: Additional bond attributes (e.g., ``type="A-B"``).
+
+        Returns:
+            The newly registered CG bond.
+        """
         bond = CGBond(a, b, **attrs)
         self.links.add(bond)
         return bond
 
-    # ========== Add Methods (add_*: add existing entities) ==========
-
     def add_bead(self, bead: Bead, /) -> Bead:
-        """Add an existing Bead object to the structure."""
+        """Register an existing :class:`Bead`.
+
+        Args:
+            bead: The bead to register.
+
+        Returns:
+            The same bead, after registration.
+        """
         self.entities.add(bead)
         return bead
 
     def add_cgbond(self, bond: CGBond, /) -> CGBond:
-        """Add an existing CGBond object to the structure."""
+        """Register an existing :class:`CGBond`.
+
+        Args:
+            bond: The CG bond to register.
+
+        Returns:
+            The same bond, after registration.
+        """
         self.links.add(bond)
         return bond
 
-    # ========== Delete Methods ==========
-
     def del_bead(self, *beads: Bead) -> None:
-        """Remove beads and all their incident CG bonds."""
+        """Remove beads (and their incident CG bonds).
+
+        Args:
+            *beads: One or more :class:`Bead` instances to remove. Each
+                bead is unregistered along with any :class:`CGBond` that
+                references it as an endpoint.
+        """
         self.remove_entity(*beads)
 
     def del_cgbond(self, *bonds: CGBond) -> None:
-        """Remove CG bonds from the structure."""
+        """Remove CG bonds.
+
+        Args:
+            *bonds: One or more :class:`CGBond` instances to remove.
+        """
         self.remove_link(*bonds)
+
+    def def_beads(self, beads_data: list[dict[str, Any]], /) -> list[Bead]:
+        """Create multiple beads from a list of attribute dicts.
+
+        Args:
+            beads_data: List of attribute dicts; each dict is forwarded as
+                ``**attrs`` to :meth:`def_bead`.
+
+        Returns:
+            List of newly registered beads, one per input dict.
+        """
+        return [self.def_bead(**a) for a in beads_data]
+
+    def def_cgbonds(
+        self,
+        bonds_data: list[tuple[Bead, Bead] | tuple[Bead, Bead, dict[str, Any]]],
+        /,
+    ) -> list[CGBond]:
+        """Create multiple CG bonds from ``(a, b)`` or ``(a, b, attrs)`` tuples.
+
+        Args:
+            bonds_data: Iterable of bond specifications. Each item is either
+                a 2-tuple ``(a, b)`` of bead endpoints or a 3-tuple
+                ``(a, b, attrs)`` where ``attrs`` is a dict forwarded as
+                ``**attrs`` to :meth:`def_cgbond`.
+
+        Returns:
+            List of newly registered CG bonds, one per input tuple.
+        """
+        out: list[CGBond] = []
+        for spec in bonds_data:
+            if len(spec) == 2:
+                a, b = spec  # type: ignore[misc]
+                attrs: dict[str, Any] = {}
+            else:
+                a, b, attrs = spec  # type: ignore[misc]
+            out.append(self.def_cgbond(a, b, **attrs))
+        return out
+
+    def add_beads(self, beads: list[Bead], /) -> list[Bead]:
+        """Register multiple existing beads.
+
+        Args:
+            beads: List of :class:`Bead` instances to register.
+
+        Returns:
+            The same list, after registration.
+        """
+        for bead in beads:
+            self.entities.add(bead)
+        return beads
+
+    def add_cgbonds(self, bonds: list[CGBond], /) -> list[CGBond]:
+        """Register multiple existing CG bonds.
+
+        Args:
+            bonds: List of :class:`CGBond` instances to register.
+
+        Returns:
+            The same list, after registration.
+        """
+        for bond in bonds:
+            self.links.add(bond)
+        return bonds
+
+    # ========== Reverse Lookup (the one extra core method) ==========
+
+    def beads_of(self, atom: "Atom") -> tuple[Bead, ...]:
+        """Return all beads whose ``bead["atoms"]`` contains ``atom``.
+
+        Justified as a core method by the same standard as :meth:`move`:
+        operates on a single conventional key (``"atoms"``) and has no
+        second reasonable implementation. Beads without an ``"atoms"``
+        key are skipped silently.
+
+        Args:
+            atom: The atom to look up.
+
+        Returns:
+            Tuple of beads referencing ``atom``. Empty if none; multiple
+            if the mapping has overlap.
+
+        Note:
+            O(N_beads × ⟨|atoms|⟩); no caching. Callers needing speed
+            should build their own ``id(atom) → list[Bead]`` index.
+        """
+        return tuple(b for b in self.beads if atom in b.get("atoms", ()))
 
     # ========== Property / Type / Selection Editing ==========
 
     def rename_type(self, old: str, new: str, *, kind: type = Bead) -> int:
-        """Rename all beads/bonds of ``kind`` whose ``type`` attribute equals ``old``.
+        """Rename all beads/bonds of ``kind`` whose ``type`` equals ``old``.
 
-        Returns the number of items updated.
+        Returns:
+            Number of items renamed.
         """
         if issubclass(kind, Link):
             items = self.links.bucket(kind)
@@ -198,13 +332,28 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
 
     def set_property(
         self,
-        selector,
+        selector: Callable[[Bead], bool],
         key: str,
         value: Any,
         *,
         kind: type = Bead,
     ) -> int:
-        """Set a property on every bead (or link) matching the callable ``selector``."""
+        """Set a property on every bead (or link) matching ``selector``.
+
+        Args:
+            selector: Callable ``(item) -> bool`` returning ``True`` for
+                items whose ``key`` should be set.
+            key: Attribute key to assign on matching items.
+            value: Value to assign.
+            kind: Item class to iterate over (default :class:`Bead`); pass a
+                :class:`Link` subclass to operate on bonds instead.
+
+        Returns:
+            Number of items modified.
+
+        Raises:
+            TypeError: If ``selector`` is not callable.
+        """
         if not callable(selector):
             raise TypeError(
                 "selector must be a callable (bead) -> bool; "
@@ -221,10 +370,20 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
                 count += 1
         return count
 
-    def select(self, predicate) -> "CoarseGrain":
-        """Return a new CoarseGrain containing only beads matching ``predicate``.
+    def select(self, predicate: Callable[[Bead], bool]) -> "CoarseGrain":
+        """Return a new CoarseGrain containing beads matching ``predicate``.
 
-        Bonds whose endpoints are fully inside the selection are carried over.
+        Bonds whose endpoints are both inside the selection are carried over.
+
+        Args:
+            predicate: Callable ``(bead) -> bool`` selecting beads to keep.
+
+        Returns:
+            A new :class:`CoarseGrain` containing the selected beads and the
+            bonds whose endpoints are entirely within the selection.
+
+        Raises:
+            TypeError: If ``predicate`` is not callable.
         """
         if not callable(predicate):
             raise TypeError(
@@ -237,51 +396,20 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
         )
         return sub  # type: ignore[return-value]
 
-    # ========== Batch Factory Methods (def_*s: create and add multiple) ==========
-
-    def def_beads(self, beads_data: list[dict[str, Any]], /) -> list[Bead]:
-        """Create multiple Beads from a list of attribute dictionaries."""
-        beads = []
-        for attrs in beads_data:
-            bead = self.def_bead(**attrs)
-            beads.append(bead)
-        return beads
-
-    def def_cgbonds(
-        self, bonds_data: list[tuple[Bead, Bead] | tuple[Bead, Bead, dict[str, Any]]], /
-    ) -> list[CGBond]:
-        """Create multiple CGBonds from a list of (ibead, jbead) or (ibead, jbead, attrs) tuples."""
-        bonds = []
-        for bond_spec in bonds_data:
-            if len(bond_spec) == 2:
-                a, b = bond_spec
-                attrs = {}
-            else:
-                a, b, attrs = bond_spec
-            bond = self.def_cgbond(a, b, **attrs)
-            bonds.append(bond)
-        return bonds
-
-    # ========== Batch Add Methods (add_*s: add multiple existing entities) ==========
-
-    def add_beads(self, beads: list[Bead], /) -> list[Bead]:
-        """Add multiple existing Bead objects to the structure."""
-        for bead in beads:
-            self.entities.add(bead)
-        return beads
-
-    def add_cgbonds(self, bonds: list[CGBond], /) -> list[CGBond]:
-        """Add multiple existing CGBond objects to the structure."""
-        for bond in bonds:
-            self.links.add(bond)
-        return bonds
-
     # ========== Spatial Operations (return self for chaining) ==========
 
     def move(
         self, delta: list[float], *, entity_type: type[Entity] = Bead
     ) -> "CoarseGrain":
-        """Move all beads by delta. Returns self for chaining."""
+        """Translate every bead by ``delta``.
+
+        Args:
+            delta: Translation vector ``[dx, dy, dz]`` in Angstroms.
+            entity_type: Entity subclass to translate (default :class:`Bead`).
+
+        Returns:
+            ``self`` for method chaining.
+        """
         super().move(delta, entity_type=entity_type)
         return self
 
@@ -293,7 +421,18 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
         *,
         entity_type: type[Entity] = Bead,
     ) -> "CoarseGrain":
-        """Rotate beads around axis. Returns self for chaining."""
+        """Rotate beads around ``axis`` by ``angle``.
+
+        Args:
+            axis: Rotation axis ``[ax, ay, az]`` (need not be unit length).
+            angle: Rotation angle in radians.
+            about: Optional pivot point ``[x, y, z]`` in Angstroms; defaults
+                to the origin.
+            entity_type: Entity subclass to rotate (default :class:`Bead`).
+
+        Returns:
+            ``self`` for method chaining.
+        """
         super().rotate(axis, angle, about=about, entity_type=entity_type)
         return self
 
@@ -304,7 +443,17 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
         *,
         entity_type: type[Entity] = Bead,
     ) -> "CoarseGrain":
-        """Scale beads by factor. Returns self for chaining."""
+        """Scale bead positions by ``factor``.
+
+        Args:
+            factor: Uniform scaling factor (dimensionless).
+            about: Optional pivot point ``[x, y, z]`` in Angstroms; defaults
+                to the origin.
+            entity_type: Entity subclass to scale (default :class:`Bead`).
+
+        Returns:
+            ``self`` for method chaining.
+        """
         super().scale(factor, about=about, entity_type=entity_type)
         return self
 
@@ -318,7 +467,20 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
         flip: bool = False,
         entity_type: type[Entity] = Bead,
     ) -> "CoarseGrain":
-        """Align beads. Returns self for chaining."""
+        """Align beads via a vector pair.
+
+        Args:
+            a: Source entity defining the start of the alignment vector.
+            b: Target entity defining the end of the alignment vector.
+            a_dir: Optional source direction ``[x, y, z]``; if omitted, the
+                vector from ``a`` to ``b`` is used.
+            b_dir: Optional target direction ``[x, y, z]``.
+            flip: If ``True``, reverse the alignment direction.
+            entity_type: Entity subclass to transform (default :class:`Bead`).
+
+        Returns:
+            ``self`` for method chaining.
+        """
         super().align(
             a, b, a_dir=a_dir, b_dir=b_dir, flip=flip, entity_type=entity_type
         )
@@ -327,222 +489,141 @@ class CoarseGrain(Struct, MembershipMixin, SpatialMixin, ConnectivityMixin):
     # ========== System Composition ==========
 
     def __iadd__(self, other: "CoarseGrain") -> "CoarseGrain":
-        """Merge another CoarseGrain into this one (in-place).
+        """Merge ``other`` into this structure in-place.
 
-        Example:
-            cg1 += cg2  # Merges cg2 into cg1
+        Args:
+            other: Source structure whose entities and links are transferred
+                into ``self``. After the call, ``other`` should not be used.
+
+        Returns:
+            ``self`` for method chaining (in-place merge).
         """
         self.merge(other)
         return self
 
     def __add__(self, other: "CoarseGrain") -> "CoarseGrain":
-        """Create a new CoarseGrain by merging two structures.
+        """Return a new structure that is the union of ``self`` and ``other``.
 
-        Example:
-            cg3 = cg1 + cg2  # Creates new structure
+        Args:
+            other: Right-hand operand whose contents are merged into a copy
+                of ``self``. Neither operand is modified.
+
+        Returns:
+            A new :class:`CoarseGrain` containing copies of all entities and
+            links from both structures.
         """
         result = self.copy()
         result.merge(other)
         return result
 
-    def replicate(self, n: int, transform=None) -> "CoarseGrain":
-        """Create n copies and merge them into a new system.
+    def replicate(
+        self,
+        n: int,
+        transform: Callable[["CoarseGrain", int], None] | None = None,
+    ) -> "CoarseGrain":
+        """Replicate ``self`` ``n`` times into a new structure.
 
         Args:
-            n: Number of copies to create.
-            transform (Callable | None): Optional callable(copy, index) -> None to transform each copy.
+            n: Number of copies.
+            transform: Optional callable ``(copy, index) -> None`` applied to
+                each replica before merging.
 
-        Example:
-            # Create 10 copies in a line
-            cg_line = cg.replicate(10, lambda mol, i: mol.move([i*5, 0, 0]))
+        Returns:
+            A new :class:`CoarseGrain` containing ``n`` merged replicas.
         """
-        result = type(self)()  # Empty system of same type
-
+        result = type(self)()
         for i in range(n):
             replica = self.copy()
             if transform is not None:
                 transform(replica, i)
             result.merge(replica)
-
         return result
 
-    def __len__(self) -> int:
-        """Return number of beads in the structure."""
-        return len(self.beads)
+    # ========== Tabular Conversion ==========
 
-    # ========== Conversion Methods ==========
+    def to_frame(self, bead_fields: list[str] | None = None) -> "Frame":
+        """Convert this CoarseGrain into a :class:`Frame`.
 
-    def to_atomistic(self) -> "Atomistic":
-        """Convert CoarseGrain structure to Atomistic representation.
-
-        Beads with atomistic member are expanded to their full atomistic structure.
-        Beads without atomistic mapping create a single atom at the bead position.
-        CGBonds are converted to atomistic bonds between representative atoms.
-
-        Returns:
-            Atomistic structure
-        """
-        from .atomistic import Atom, Atomistic, Bond
-
-        result = Atomistic()
-
-        # Map beads to their representative atoms (for bond creation)
-        bead_to_atom: dict[Bead, Atom] = {}
-
-        # Process each bead
-        for bead in self.beads:
-            if bead.atomistic is not None:
-                # Bead has atomistic mapping - use reference and merge
-                # Get first atom as representative for bond creation
-                atoms_list = list(bead.atomistic.atoms)
-                if atoms_list:
-                    bead_to_atom[bead] = atoms_list[0]
-
-                # Merge the referenced atomistic structure
-                result.merge(bead.atomistic)
-            else:
-                # No atomistic mapping - create single atom at bead position
-                atom_attrs = {}
-
-                # Copy position if available
-                if "x" in bead.data:
-                    atom_attrs["x"] = bead.data["x"]
-                if "y" in bead.data:
-                    atom_attrs["y"] = bead.data["y"]
-                if "z" in bead.data:
-                    atom_attrs["z"] = bead.data["z"]
-
-                # Copy type as element placeholder if available
-                if "type" in bead.data:
-                    atom_attrs["element"] = bead.data["type"]
-
-                # Create atom
-                atom = result.def_atom(**atom_attrs)
-                bead_to_atom[bead] = atom
-
-        # Convert CGBonds to atomistic bonds
-        for cgbond in self.cgbonds:
-            ibead = cgbond.ibead
-            jbead = cgbond.jbead
-
-            # Get representative atoms
-            if ibead in bead_to_atom and jbead in bead_to_atom:
-                iatom = bead_to_atom[ibead]
-                jatom = bead_to_atom[jbead]
-
-                # Create bond with attributes from CGBond
-                bond_attrs = dict(cgbond.data)
-                result.def_bond(iatom, jatom, **bond_attrs)
-
-        return result
-
-    @classmethod
-    def from_atomistic(
-        cls, atomistic: "Atomistic", bead_mask: "np.ndarray"
-    ) -> "CoarseGrain":
-        """Create CoarseGrain structure from Atomistic using a bead mask.
+        Mirrors :meth:`molpy.core.atomistic.Atomistic.to_frame`. Beads are
+        flattened into a ``"beads"`` :class:`Block` (struct-of-arrays);
+        CG bonds, when present, become a ``"cgbonds"`` block carrying
+        integer endpoint indices ``ibead`` / ``jbead`` plus any remaining
+        bond attributes.
 
         Args:
-            atomistic: Atomistic structure to convert
-            bead_mask: Numpy array where each element indicates which bead the atom belongs to.
-                      Can be boolean (True = bead 0) or integer indices.
+            bead_fields: Optional whitelist of bead dict keys to extract.
+                If ``None``, every key encountered on any bead is included.
+                Note: a bead may carry a ``"atoms"`` convention key whose
+                value is a tuple of :class:`Atom` references; including
+                that key produces an object-dtype column. Pass an explicit
+                whitelist to skip it when writing to numerical formats.
 
         Returns:
-            CoarseGrain structure with beads mapped to atomistic substructures
+            A :class:`Frame` with a ``"beads"`` block and (if any CG bonds
+            exist) a ``"cgbonds"`` block. The frame carries no
+            :class:`Box`; callers attach one as needed.
 
-        Example:
-            >>> atomistic = Atomistic()
-            >>> # ... create atoms and bonds ...
-            >>> # Group atoms: [0,1,2] -> bead 0, [3,4] -> bead 1
-            >>> mask = np.array([0, 0, 0, 1, 1])
-            >>> cg = CoarseGrain.from_atomistic(atomistic, mask)
+        Raises:
+            ValueError: If a CG bond references a bead that is not
+                registered in this structure.
         """
         import numpy as np
 
-        result = cls()
+        from .frame import Block, Frame
 
-        # Get atoms list
-        atoms_list = list(atomistic.atoms)
+        frame = Frame()
+        beads = list(self.beads)
+        cgbonds = list(self.cgbonds)
 
-        if len(atoms_list) != len(bead_mask):
-            raise ValueError(
-                f"Bead mask length ({len(bead_mask)}) must match number of atoms ({len(atoms_list)})"
-            )
+        # ---- beads block ----
+        if bead_fields is None:
+            keys: set[str] = set()
+            for bead in beads:
+                keys.update(bead.keys())
+        else:
+            keys = set(bead_fields)
 
-        # Group atoms by bead index
-        bead_indices = np.unique(bead_mask)
-        bead_to_atoms: dict[int, list] = {int(idx): [] for idx in bead_indices}
+        bead_dict: dict[str, list[Any]] = {k: [] for k in keys}
+        bead_index: dict[int, int] = {}
+        for bead in beads:
+            bead_index[id(bead)] = len(bead_index)
+            for key in keys:
+                bead_dict[key].append(bead.get(key, None))
 
-        for atom, bead_idx in zip(atoms_list, bead_mask):
-            bead_to_atoms[int(bead_idx)].append(atom)
+        bead_arrays = {
+            k: np.array(v, dtype=object) if k == "atoms" else np.array(v)
+            for k, v in bead_dict.items()
+        }
+        frame["beads"] = Block.from_dict(bead_arrays)
 
-        # Map bead index to Bead object
-        idx_to_bead: dict[int, Bead] = {}
+        # ---- cgbonds block ----
+        if cgbonds:
+            cgbond_dict: dict[str, list[Any]] = {"ibead": [], "jbead": []}
+            all_bond_keys: set[str] = set()
+            for bond in cgbonds:
+                all_bond_keys.update(bond.keys())
+            for key in all_bond_keys:
+                if key not in ("ibead", "jbead"):
+                    cgbond_dict[key] = []
 
-        # Create beads from atom groups
-        for bead_idx, atom_group in bead_to_atoms.items():
-            # Calculate center of mass for bead position
-            positions = []
-            for atom in atom_group:
-                x = atom.get("x", 0.0)
-                y = atom.get("y", 0.0)
-                z = atom.get("z", 0.0)
-                positions.append([x, y, z])
+            for k, bond in enumerate(cgbonds):
+                if id(bond.ibead) not in bead_index:
+                    raise ValueError(
+                        f"CGBond {k + 1}: ibead (id={id(bond.ibead)}) is not "
+                        f"registered in this CoarseGrain."
+                    )
+                if id(bond.jbead) not in bead_index:
+                    raise ValueError(
+                        f"CGBond {k + 1}: jbead (id={id(bond.jbead)}) is not "
+                        f"registered in this CoarseGrain."
+                    )
+                cgbond_dict["ibead"].append(bead_index[id(bond.ibead)])
+                cgbond_dict["jbead"].append(bead_index[id(bond.jbead)])
+                for key in all_bond_keys:
+                    if key not in ("ibead", "jbead"):
+                        cgbond_dict[key].append(bond.get(key, None))
 
-            positions_array = np.array(positions)
-            center = positions_array.mean(axis=0)
+            cgbond_arrays = {k: np.array(v) for k, v in cgbond_dict.items()}
+            frame["cgbonds"] = Block.from_dict(cgbond_arrays)
 
-            # Extract subgraph for this bead
-            from .atomistic import Atomistic
-
-            subgraph, _ = atomistic.extract_subgraph(
-                center_entities=atom_group,
-                radius=0,  # Only include atoms in the group
-                entity_type=type(atom_group[0]),
-                link_type=(
-                    type(list(atomistic.bonds)[0]) if len(atomistic.bonds) > 0 else None
-                ),
-            )
-
-            # Create bead with atomistic mapping (reference, not copy)
-            bead = result.def_bead(
-                atomistic=subgraph,
-                x=float(center[0]),
-                y=float(center[1]),
-                z=float(center[2]),
-            )
-
-            idx_to_bead[bead_idx] = bead
-
-        # Infer CGBonds from atomistic bonds crossing bead boundaries
-        bead_pairs: set[tuple[int, int]] = set()
-
-        for bond in atomistic.bonds:
-            # Find which beads the bond endpoints belong to
-            atom_i = bond.itom
-            atom_j = bond.jtom
-
-            # Find bead indices
-            try:
-                idx_i = atoms_list.index(atom_i)
-                idx_j = atoms_list.index(atom_j)
-            except ValueError:
-                continue  # Skip if atoms not found
-
-            bead_idx_i = int(bead_mask[idx_i])
-            bead_idx_j = int(bead_mask[idx_j])
-
-            # If atoms belong to different beads, create CGBond
-            if bead_idx_i != bead_idx_j:
-                # Ensure consistent ordering to avoid duplicates
-                pair = tuple(sorted([bead_idx_i, bead_idx_j]))
-                bead_pairs.add(pair)
-
-        # Create CGBonds
-        for bead_idx_i, bead_idx_j in bead_pairs:
-            if bead_idx_i in idx_to_bead and bead_idx_j in idx_to_bead:
-                bead_i = idx_to_bead[bead_idx_i]
-                bead_j = idx_to_bead[bead_idx_j]
-                result.def_cgbond(bead_i, bead_j)
-
-        return result
+        return frame

--- a/src/molpy/embed/__init__.py
+++ b/src/molpy/embed/__init__.py
@@ -1,0 +1,62 @@
+"""3D coordinate generation for molpy molecules.
+
+Thin Python wrapper around the molrs Rust ``embed`` pipeline, exposed via the
+``molrs`` binary extension. The heavy lifting — fragment / distance-geometry
+build, energy minimisation, rotor search, stereo guard — runs inside molrs;
+this module only marshals :class:`molpy.Atomistic` across that boundary.
+
+The existing RDKit adapter (:mod:`molpy.adapter.rdkit`) and the RDKit-based
+``Generate3D`` compute node (:mod:`molpy.compute.rdkit`) remain available
+as alternative backends and are unaffected by this module.
+"""
+
+from __future__ import annotations
+
+import molrs
+
+from molpy.core._molrs import from_molrs, to_molrs
+from molpy.core.atomistic import Atomistic
+
+from .report import EmbedReport, StageReport
+
+__all__ = ["EmbedReport", "StageReport", "generate_3d"]
+
+
+def generate_3d(
+    mol: Atomistic,
+    *,
+    speed: str = "medium",
+    add_hydrogens: bool = True,
+    rng_seed: int | None = None,
+) -> tuple[Atomistic, EmbedReport]:
+    """Generate 3D coordinates via the molrs ``embed`` Rust pipeline.
+
+    Parameters
+    ----------
+    mol:
+        Input molecular graph. Element symbols and bond orders are required;
+        coordinates may be missing.
+    speed:
+        Quality preset, one of ``"fast"``, ``"medium"``, or ``"better"``.
+    add_hydrogens:
+        Add explicit hydrogens before embedding.
+    rng_seed:
+        Optional deterministic RNG seed.
+
+    Returns
+    -------
+    tuple[Atomistic, EmbedReport]
+        Fresh atomistic structure with generated coordinates plus a per-stage
+        report. The input ``mol`` is not mutated.
+    """
+    if len(list(mol.atoms)) == 0:
+        raise ValueError("cannot generate 3D structure for empty molecule")
+
+    rs_in = to_molrs(mol)
+    native_opts = molrs.EmbedOptions(
+        speed=speed, add_hydrogens=bool(add_hydrogens), seed=rng_seed
+    )
+    result = molrs.generate_3d(rs_in, native_opts)
+    out = from_molrs(result.mol, template=mol)
+    report = EmbedReport.from_native(result.report)
+    return out, report

--- a/src/molpy/embed/report.py
+++ b/src/molpy/embed/report.py
@@ -1,0 +1,52 @@
+"""Stage-level reporting for 3D generation.
+
+Mirrors the molrs ``EmbedReport`` and ``StageReport`` types in plain Python
+dataclasses so molpy callers do not have to keep a live reference to the
+underlying Rust object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import molrs
+
+
+@dataclass(frozen=True)
+class StageReport:
+    """Per-stage execution metrics."""
+
+    stage: str
+    energy_before: float | None
+    energy_after: float | None
+    steps: int
+    converged: bool
+    elapsed_ms: int
+
+    @classmethod
+    def from_native(cls, native: "molrs.StageReport") -> "StageReport":
+        return cls(
+            stage=str(native.stage),
+            energy_before=native.energy_before,
+            energy_after=native.energy_after,
+            steps=int(native.steps),
+            converged=bool(native.converged),
+            elapsed_ms=int(native.elapsed_ms),
+        )
+
+
+@dataclass(frozen=True)
+class EmbedReport:
+    """End-to-end generation report."""
+
+    final_energy: float | None
+    warnings: list[str] = field(default_factory=list)
+    stages: list[StageReport] = field(default_factory=list)
+
+    @classmethod
+    def from_native(cls, native: "molrs.EmbedReport") -> "EmbedReport":
+        return cls(
+            final_energy=native.final_energy,
+            warnings=list(native.warnings),
+            stages=[StageReport.from_native(s) for s in native.stages],
+        )

--- a/src/molpy/io/__init__.py
+++ b/src/molpy/io/__init__.py
@@ -80,6 +80,7 @@ from .readers import (
     read_gro,
     read_h5,
     read_h5_trajectory,
+    read_LAMMPS_log,
     read_lammps_data,
     read_lammps_forcefield,
     read_lammps_molecule,
@@ -110,7 +111,21 @@ from .trajectory.lammps import (
 from .trajectory.xyz import XYZTrajectoryReader, XYZTrajectoryWriter
 
 # 4. Log Readers
-from .log.lammps import LAMMPSLog
+from .log.lammps import (
+    LAMMPSCPUUse,
+    LAMMPSLoadBalance,
+    LAMMPSLog,
+    LAMMPSLogHeader,
+    LAMMPSLoopTime,
+    LAMMPSMemoryUsage,
+    LAMMPSNeighborStatistics,
+    LAMMPSPerformance,
+    LAMMPSRun,
+    LAMMPSThermo,
+    LAMMPSTimingBreakdown,
+    LAMMPSTimingRow,
+    LAMMPSWarning,
+)
 from .writers import (
     write_gro,
     write_h5,
@@ -140,6 +155,7 @@ __all__ = [
     "read_amber_prmtop",
     "read_gro",
     "read_h5",
+    "read_LAMMPS_log",
     "read_lammps_data",
     "read_lammps_forcefield",
     "read_lammps_molecule",
@@ -212,7 +228,19 @@ __all__ = [
     "LammpsTrajectoryWriter",
     "XYZTrajectoryWriter",
     # Log Readers
+    "LAMMPSCPUUse",
+    "LAMMPSLoadBalance",
     "LAMMPSLog",
+    "LAMMPSLogHeader",
+    "LAMMPSLoopTime",
+    "LAMMPSMemoryUsage",
+    "LAMMPSNeighborStatistics",
+    "LAMMPSPerformance",
+    "LAMMPSRun",
+    "LAMMPSThermo",
+    "LAMMPSTimingBreakdown",
+    "LAMMPSTimingRow",
+    "LAMMPSWarning",
     # Utility Classes
     "ZipReader",
 ]

--- a/src/molpy/io/data/lammps.py
+++ b/src/molpy/io/data/lammps.py
@@ -53,7 +53,9 @@ class LammpsDataReader(DataReader):
 
         # Parse header and set up box
         header_info = self._parse_header(sections.get("header", []))
-        frame.box = self._create_box(header_info["box_bounds"])
+        frame.box = self._create_box(
+            header_info["box_bounds"], header_info.get("tilts")
+        )
 
         # Parse masses if present
         masses = self._parse_masses(sections.get("Masses", []))
@@ -142,6 +144,11 @@ class LammpsDataReader(DataReader):
             "angles",
             "dihedrals",
             "impropers",
+            "bodies",
+            "velocities",
+            "ellipsoids",
+            "lines",
+            "triangles",
             "atom type labels",
             "bond type labels",
             "angle type labels",
@@ -183,73 +190,105 @@ class LammpsDataReader(DataReader):
     def _parse_header(self, header_lines: list[str]) -> dict[str, Any]:
         """Parse header information."""
         counts = {}
-        box_bounds = {}
+        box_bounds: dict[str, tuple[float, float]] = {}
+        tilts: tuple[float, float, float] | None = None
 
         for line in header_lines:
             parts = line.split()
             if len(parts) < 2:
                 continue
 
-            try:
-                count = int(parts[0])
-                if "atoms" in line.lower() and not line.lower().startswith("atoms"):
-                    counts["atoms"] = count
-                elif "bonds" in line.lower() and not line.lower().startswith("bonds"):
-                    counts["bonds"] = count
-                elif "angles" in line.lower() and not line.lower().startswith("angles"):
-                    counts["angles"] = count
-                elif "dihedrals" in line.lower() and not line.lower().startswith(
-                    "dihedrals"
-                ):
-                    counts["dihedrals"] = count
-                elif "impropers" in line.lower() and not line.lower().startswith(
-                    "impropers"
-                ):
-                    counts["impropers"] = count
-                elif "atom types" in line.lower():
-                    counts["atom_types"] = count
-                elif "bond types" in line.lower():
-                    counts["bond_types"] = count
-                elif "angle types" in line.lower():
-                    counts["angle_types"] = count
-                elif "dihedral types" in line.lower():
-                    counts["dihedral_types"] = count
-                elif "improper types" in line.lower():
-                    counts["improper_types"] = count
-                elif "xlo xhi" in line.lower():
-                    box_bounds["x"] = (float(parts[0]), float(parts[1]))
-                elif "ylo" in line.lower() and "yhi" in line.lower():
-                    box_bounds["y"] = (float(parts[0]), float(parts[1]))
-                elif "zlo zhi" in line.lower():
-                    box_bounds["z"] = (float(parts[0]), float(parts[1]))
-            except (ValueError, IndexError):
+            line_lower = line.lower()
+            tokens_lower = [p.lower() for p in parts]
+
+            # Box-bound lines have float values; parse them before the int-count branch.
+            if "xlo" in tokens_lower and "xhi" in tokens_lower:
+                box_bounds["x"] = self._parse_box_bound(parts, line)
+                continue
+            if "ylo" in tokens_lower and "yhi" in tokens_lower:
+                box_bounds["y"] = self._parse_box_bound(parts, line)
+                continue
+            if "zlo" in tokens_lower and "zhi" in tokens_lower:
+                box_bounds["z"] = self._parse_box_bound(parts, line)
                 continue
 
-        return {"counts": counts, "box_bounds": box_bounds if box_bounds else None}
+            # Triclinic tilt factors: "xy xz yz <value-x> <value-y> <value-z>"
+            # with values written first per LAMMPS convention.
+            if "xy" in tokens_lower and "xz" in tokens_lower and "yz" in tokens_lower:
+                try:
+                    tilts = (float(parts[0]), float(parts[1]), float(parts[2]))
+                except (ValueError, IndexError) as exc:
+                    raise ValueError(
+                        f"Failed to parse LAMMPS tilt factors line: {line!r}"
+                    ) from exc
+                continue
 
-    def _create_box(self, box_bounds: dict[str, tuple[float, float]] | None) -> Box:
-        """Create Box from bounds."""
-        if not box_bounds:
-            # Default box
-            return Box(np.array([10.0, 10.0, 10.0]))
+            try:
+                count = int(parts[0])
+            except ValueError:
+                continue
+
+            if "atoms" in line_lower and not line_lower.startswith("atoms"):
+                counts["atoms"] = count
+            elif "bonds" in line_lower and not line_lower.startswith("bonds"):
+                counts["bonds"] = count
+            elif "angles" in line_lower and not line_lower.startswith("angles"):
+                counts["angles"] = count
+            elif "dihedrals" in line_lower and not line_lower.startswith("dihedrals"):
+                counts["dihedrals"] = count
+            elif "impropers" in line_lower and not line_lower.startswith("impropers"):
+                counts["impropers"] = count
+            elif "atom types" in line_lower:
+                counts["atom_types"] = count
+            elif "bond types" in line_lower:
+                counts["bond_types"] = count
+            elif "angle types" in line_lower:
+                counts["angle_types"] = count
+            elif "dihedral types" in line_lower:
+                counts["dihedral_types"] = count
+            elif "improper types" in line_lower:
+                counts["improper_types"] = count
+
+        return {
+            "counts": counts,
+            "box_bounds": box_bounds if box_bounds else None,
+            "tilts": tilts,
+        }
+
+    @staticmethod
+    def _parse_box_bound(parts: list[str], line: str) -> tuple[float, float]:
+        """Parse a `lo hi <axis>lo <axis>hi` line into a (lo, hi) tuple."""
+        try:
+            return (float(parts[0]), float(parts[1]))
+        except (ValueError, IndexError) as exc:
+            raise ValueError(
+                f"Failed to parse LAMMPS box bounds line: {line!r}"
+            ) from exc
+
+    def _create_box(
+        self,
+        box_bounds: dict[str, tuple[float, float]] | None,
+        tilts: tuple[float, float, float] | None = None,
+    ) -> Box:
+        """Create Box from parsed bounds. Raises if any axis is missing."""
+        required_axes = ("x", "y", "z")
+        missing = (
+            list(required_axes)
+            if not box_bounds
+            else [axis for axis in required_axes if axis not in box_bounds]
+        )
+        if missing:
+            raise ValueError(
+                f"LAMMPS data file {self._path} is missing box bounds for axis "
+                f"{missing}. Required header lines: 'xlo xhi', 'ylo yhi', 'zlo zhi'."
+            )
 
         lengths = np.array(
-            [
-                box_bounds.get("x", (0.0, 10.0))[1]
-                - box_bounds.get("x", (0.0, 10.0))[0],
-                box_bounds.get("y", (0.0, 10.0))[1]
-                - box_bounds.get("y", (0.0, 10.0))[0],
-                box_bounds.get("z", (0.0, 10.0))[1]
-                - box_bounds.get("z", (0.0, 10.0))[0],
-            ]
+            [box_bounds[axis][1] - box_bounds[axis][0] for axis in required_axes]
         )
-        origin = np.array(
-            [
-                box_bounds.get("x", (0.0, 10.0))[0],
-                box_bounds.get("y", (0.0, 10.0))[0],
-                box_bounds.get("z", (0.0, 10.0))[0],
-            ]
-        )
+        origin = np.array([box_bounds[axis][0] for axis in required_axes])
+        if tilts is not None and any(t != 0.0 for t in tilts):
+            return Box.tric(lengths, tilts, origin=origin)
         return Box(lengths, origin=origin)
 
     def _parse_masses(self, mass_lines: list[str]) -> dict[str, float]:
@@ -409,16 +448,25 @@ class LammpsDataReader(DataReader):
             header = ["id", "mol", "type", "q", "x", "y", "z"]
         elif self.atom_style == "charge":
             header = ["id", "type", "q", "x", "y", "z"]
-        else:  # atomic
+        elif self.atom_style == "body":
+            header = ["id", "type", "bodyflag", "mass", "x", "y", "z"]
+        elif self.atom_style == "atomic":
             header = ["id", "type", "x", "y", "z"]
+        else:
+            raise ValueError(
+                f"Unsupported LAMMPS atom_style {self.atom_style!r}. "
+                "Supported: 'full', 'charge', 'atomic', 'body'."
+            )
 
         csv_lines.append(" ".join(header))
 
-        # Add data lines directly
+        # Add data lines, truncating any trailing image flags (ix iy iz) or
+        # body-specific extras so columns line up with the header.
+        n_cols = len(header)
         for line in atom_lines:
             parts = line.split()
-            if len(parts) >= len(header):
-                csv_lines.append(line)
+            if len(parts) >= n_cols:
+                csv_lines.append(" ".join(parts[:n_cols]))
 
         # Parse using Block.from_csv with space delimiter
         csv_string = "\n".join(csv_lines)
@@ -426,8 +474,11 @@ class LammpsDataReader(DataReader):
             StringIO(csv_string), delimiter=" ", skipinitialspace=True
         )
 
-        # Add mass information
-        if block.nrows > 0:
+        # Add mass information. atom_style="body" already carries per-atom
+        # mass in the atoms section; do not overwrite it from the (absent)
+        # Masses section. Other styles look mass up by atom type, falling
+        # back to 1.0 when the file has no Masses section.
+        if block.nrows > 0 and "mass" not in block:
             mass_values = []
             for type_str in block["type"]:
                 mass_values.append(masses.get(str(type_str), 1.0))

--- a/src/molpy/io/log/__init__.py
+++ b/src/molpy/io/log/__init__.py
@@ -1,0 +1,35 @@
+"""Log file readers."""
+
+from .lammps import (
+    LAMMPSCPUUse,
+    LAMMPSLoadBalance,
+    LAMMPSLog,
+    LAMMPSLogHeader,
+    LAMMPSLoopTime,
+    LAMMPSMemoryUsage,
+    LAMMPSNeighborStatistics,
+    LAMMPSPerformance,
+    LAMMPSRun,
+    LAMMPSThermo,
+    LAMMPSTimingBreakdown,
+    LAMMPSTimingRow,
+    LAMMPSWarning,
+    read_LAMMPS_log,
+)
+
+__all__ = [
+    "LAMMPSCPUUse",
+    "LAMMPSLoadBalance",
+    "LAMMPSLog",
+    "LAMMPSLogHeader",
+    "LAMMPSLoopTime",
+    "LAMMPSMemoryUsage",
+    "LAMMPSNeighborStatistics",
+    "LAMMPSPerformance",
+    "LAMMPSRun",
+    "LAMMPSThermo",
+    "LAMMPSTimingBreakdown",
+    "LAMMPSTimingRow",
+    "LAMMPSWarning",
+    "read_LAMMPS_log",
+]

--- a/src/molpy/io/log/lammps.py
+++ b/src/molpy/io/log/lammps.py
@@ -1,114 +1,776 @@
 """LAMMPS log file parser.
 
-Parses LAMMPS log files to extract thermodynamic output and simulation metadata.
+This module parses the standard LAMMPS run output structure documented in
+``Run_output.html``: thermo tables, loop timing, performance summaries,
+CPU/MPI timing, load-balance statistics, neighbor statistics, and warnings.
+Unrecognized lines are preserved so callers can still inspect information that
+does not yet have a structured representation.
 """
 
-# author: Roy Kid
-# contact: lijichen365@126.com
-# date: 2023-09-29
-# version: 0.0.2
+from __future__ import annotations
 
 import re
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 
-_THERMO_BLOCK = re.compile(
-    r"Per MPI rank[^\n]*\n(?P<body>.*?)Loop time",
-    re.DOTALL,
+PathLike = str | Path
+
+_MEMORY_RE = re.compile(
+    r"^Per MPI rank memory allocation \(min/avg/max\) = "
+    r"(?P<minimum>\S+) \| (?P<average>\S+) \| (?P<maximum>\S+) (?P<units>\S+)"
 )
+_LOOP_TIME_RE = re.compile(
+    r"^Loop time of (?P<seconds>\S+) on (?P<procs>\d+) procs"
+    r"(?: for (?P<steps>\d+) steps with (?P<atoms>\d+) atoms)?"
+)
+_PERFORMANCE_RE = re.compile(
+    r"^Performance:\s+"
+    r"(?P<ns_per_day>\S+) ns/day,\s+"
+    r"(?P<hours_per_ns>\S+) hours/ns,\s+"
+    r"(?P<timesteps_per_second>\S+) timesteps/s"
+    r"(?:,\s+(?P<atom_steps_per_second>\S+) (?P<atom_steps_units>\S+))?"
+)
+_CPU_USE_RE = re.compile(
+    r"^(?P<percent>\S+)% CPU use with (?P<MPI_tasks>\d+) MPI tasks"
+    r"(?: x (?P<OMP_threads>\d+) OpenMP threads)?"
+)
+_LOAD_BALANCE_RE = re.compile(
+    r"^(?P<name>Nlocal|Nghost|Neighs):\s+"
+    r"(?P<average>\S+) ave (?P<maximum>\S+) max (?P<minimum>\S+) min"
+)
+_WARNING_RE = re.compile(r"^WARNING:\s*(?P<message>.*)")
 
 
-class LAMMPSLog:
-    """
-    Parser for LAMMPS log files.
+@dataclass(frozen=True, slots=True)
+class LAMMPSLogHeader:
+    """Header text before the first parsed LAMMPS run block."""
 
-    Extracts version info and thermodynamic output from LAMMPS log files.
-    Handles multiple successive ``run`` blocks (each producing its own
-    ``Per MPI rank ... Loop time`` section).
+    lines: tuple[str, ...]
 
-    Args:
-        file: Path to LAMMPS log file
-        style: Log style (default: "default" — matches ``thermo_style custom``)
-    """
-
-    def __init__(self, file: str | Path, style: str = "default"):
-        self.file = Path(file)
-        self.info: dict[str, Any] = {
-            "n_stages": 0,
-            "stages": [],
-        }
-        self.style = style
-
-    def read(self) -> "LAMMPSLog":
-        """Read and parse the log file. Returns self for chaining."""
-        with open(self.file) as fh:
-            log_str = fh.read()
-
-        self.read_version(log_str)
-        self.read_thermo(log_str, self.style)
-        return self
-
-    def read_version(self, text: str) -> None:
-        """Extract LAMMPS version from log text (the first line)."""
-        index = text.find("\n")
-        self["version"] = text[:index] if index >= 0 else text
-
-    def read_thermo(self, text: str, style: str) -> None:
-        """Parse thermodynamic output stages from log.
-
-        Captures every ``Per MPI rank ... Loop time`` block. The first line of
-        each block holds whitespace-separated column names; subsequent lines
-        are numeric data rows.
-        """
-        if style != "default":
-            return
-
-        for match in _THERMO_BLOCK.finditer(text):
-            body = match.group("body")
-            lines = [line for line in body.splitlines() if line.strip()]
-            if len(lines) < 2:
-                continue
-            fields = lines[0].split()
-            data_lines = lines[1:]
-            try:
-                array = np.loadtxt(
-                    data_lines,
-                    dtype=np.dtype({"names": fields, "formats": ["f8"] * len(fields)}),
-                    ndmin=1,
-                )
-            except ValueError:
-                continue
-            self["stages"].append(array)
-        self["n_stages"] = len(self["stages"])
+    @property
+    def raw_text(self) -> str:
+        """Header lines joined by newlines."""
+        return "\n".join(self.lines)
 
     def to_dict(self) -> dict[str, Any]:
-        """JSON-friendly serialization (used by HTTP transports).
+        """Return a JSON-friendly representation."""
+        return {"lines": list(self.lines), "raw_text": self.raw_text}
 
-        Each stage becomes ``{"columns": [...], "rows": [[...], ...]}``.
-        Step (if present) is the first column; downstream consumers may treat
-        it as the x-axis.
-        """
-        stages: list[dict[str, Any]] = []
-        for array in self["stages"]:
-            columns = list(array.dtype.names) if array.dtype.names else []
-            rows = (
-                [[float(value) for value in record] for record in array.tolist()]
-                if columns
-                else []
-            )
-            stages.append({"columns": columns, "rows": rows})
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSMemoryUsage:
+    """``Per MPI rank memory allocation`` line."""
+
+    minimum: float
+    average: float
+    maximum: float
+    units: str
+    raw_line: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSThermo:
+    """LAMMPS thermo table with dynamic columns."""
+
+    columns: tuple[str, ...]
+    data: np.ndarray
+    raw_lines: tuple[str, ...]
+
+    @property
+    def n_rows(self) -> int:
+        """Number of thermo rows."""
+        return int(self.data.shape[0])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
         return {
-            "version": self.info.get("version"),
-            "n_stages": self["n_stages"],
+            "columns": list(self.columns),
+            "rows": _array_rows(self.data),
+            "raw_lines": list(self.raw_lines),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSLoopTime:
+    """``Loop time`` summary line."""
+
+    seconds: float
+    procs: int
+    steps: int | None
+    atoms: int | None
+    raw_line: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSPerformance:
+    """LAMMPS ``Performance`` summary line."""
+
+    ns_per_day: float
+    hours_per_ns: float
+    timesteps_per_second: float
+    atom_steps_per_second: float | None
+    atom_steps_units: str | None
+    raw_line: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSCPUUse:
+    """``% CPU use`` summary line."""
+
+    percent: float
+    MPI_tasks: int
+    OMP_threads: int | None
+    raw_line: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSTimingRow:
+    """One row from a LAMMPS timing breakdown table."""
+
+    section: str
+    min_time: float
+    avg_time: float
+    max_time: float
+    percent_varavg: float
+    percent_total: float
+    raw_line: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSTimingBreakdown:
+    """``MPI task timing breakdown`` or thread timing table."""
+
+    title: str
+    rows: tuple[LAMMPSTimingRow, ...]
+    raw_lines: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSLoadBalance:
+    """LAMMPS load-balance statistic plus optional histogram."""
+
+    name: str
+    average: float
+    maximum: float
+    minimum: float
+    histogram: tuple[int, ...]
+    raw_lines: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSNeighborStatistics:
+    """Neighbor-list statistics emitted after a run."""
+
+    total_neighbors: int | None
+    ave_neighs_per_atom: float | None
+    ave_special_neighs_per_atom: float | None
+    neighbor_list_builds: int | None
+    dangerous_builds: int | None
+    raw_lines: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSWarning:
+    """A warning line from the LAMMPS log."""
+
+    message: str
+    raw_line: str
+    line_number: int | None = None
+    run_index: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LAMMPSRun:
+    """One LAMMPS run output block."""
+
+    index: int
+    setup_log: tuple[str, ...]
+    memory: LAMMPSMemoryUsage | None
+    thermo: LAMMPSThermo | None
+    loop_time: LAMMPSLoopTime | None
+    performance: LAMMPSPerformance | None
+    CPU_use: LAMMPSCPUUse | None
+    MPI_task_timing: LAMMPSTimingBreakdown | None
+    thread_timing: LAMMPSTimingBreakdown | None
+    load_balance: tuple[LAMMPSLoadBalance, ...]
+    neighbor_statistics: LAMMPSNeighborStatistics | None
+    warnings: tuple[LAMMPSWarning, ...]
+    unparsed_log: tuple[str, ...]
+    raw_text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation."""
+        return _dataclass_to_dict(self)
+
+
+@dataclass(slots=True, init=False)
+class LAMMPSLog:
+    """Parsed LAMMPS log.
+
+    Args:
+        file: Path to a LAMMPS log file.
+        style: Thermo style. Only ``"default"`` is currently parsed.
+
+    Notes:
+        The class keeps the historical ``LAMMPSLog(path).read()`` workflow and
+        ``log["stages"]`` compatibility while exposing the new dataclass-shaped
+        result through attributes such as ``runs``.
+    """
+
+    path: Path
+    version: str | None
+    header: LAMMPSLogHeader
+    runs: tuple[LAMMPSRun, ...]
+    total_wall_time: str | None
+    warnings: tuple[LAMMPSWarning, ...]
+    raw_text: str
+    style: str
+    info: dict[str, Any]
+
+    def __init__(self, file: PathLike, style: str = "default"):
+        self.path = Path(file)
+        self.version = None
+        self.header = LAMMPSLogHeader(lines=())
+        self.runs = ()
+        self.total_wall_time = None
+        self.warnings = ()
+        self.raw_text = ""
+        self.style = style
+        self.info = {"n_stages": 0, "stages": []}
+
+    @property
+    def file(self) -> Path:
+        """Compatibility alias for the historical ``file`` attribute."""
+        return self.path
+
+    def read(self) -> "LAMMPSLog":
+        """Read and parse the log file. Returns ``self`` for chaining."""
+        text = self.path.read_text()
+        parsed = _parse_LAMMPS_log_text(self.path, text, self.style)
+        self.version = parsed.version
+        self.header = parsed.header
+        self.runs = parsed.runs
+        self.total_wall_time = parsed.total_wall_time
+        self.warnings = parsed.warnings
+        self.raw_text = parsed.raw_text
+        self.info = {
+            "version": self.version,
+            "n_stages": len(self.legacy_thermo_stages()),
+            "stages": self.legacy_thermo_stages(),
+        }
+        return self
+
+    def legacy_thermo_stages(self) -> list[np.ndarray]:
+        """Return thermo arrays using the historical ``stages`` shape."""
+        return [run.thermo.data for run in self.runs if run.thermo is not None]
+
+    def read_version(self, text: str) -> None:
+        """Extract the LAMMPS version line into the compatibility mapping."""
+        self.version = _first_line(text)
+        self.info["version"] = self.version
+
+    def read_thermo(self, text: str, style: str) -> None:
+        """Parse thermo tables into the compatibility mapping."""
+        parsed = _parse_LAMMPS_log_text(self.path, text, style)
+        stages = [run.thermo.data for run in parsed.runs if run.thermo is not None]
+        self.info["stages"] = stages
+        self.info["n_stages"] = len(stages)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation.
+
+        ``stages`` and ``n_stages`` are retained for compatibility. New code
+        should prefer ``runs``.
+        """
+        stages = [run.thermo.to_dict() for run in self.runs if run.thermo is not None]
+        return {
+            "path": str(self.path),
+            "version": self.version,
+            "header": self.header.to_dict(),
+            "runs": [run.to_dict() for run in self.runs],
+            "total_wall_time": self.total_wall_time,
+            "warnings": [warning.to_dict() for warning in self.warnings],
+            "raw_text": self.raw_text,
+            "n_stages": len(stages),
             "stages": stages,
         }
 
     def __getitem__(self, key: str) -> Any:
-        """Get info field by key."""
+        """Get a compatibility info field by key."""
         return self.info[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Set info field by key."""
+        """Set a compatibility info field by key."""
         self.info[key] = value
+
+
+def read_LAMMPS_log(file: PathLike) -> LAMMPSLog:
+    """Read a LAMMPS log file into a nested dataclass result.
+
+    Args:
+        file: Path to the LAMMPS log file.
+
+    Returns:
+        Parsed ``LAMMPSLog`` object.
+    """
+    return LAMMPSLog(file).read()
+
+
+def _parse_LAMMPS_log_text(path: Path, text: str, style: str) -> LAMMPSLog:
+    lines = text.splitlines()
+    run_ranges = _find_run_ranges(lines)
+    header_end = run_ranges[0][0] if run_ranges else len(lines)
+    total_wall_time = _parse_total_wall_time(lines)
+    if total_wall_time is not None and not run_ranges:
+        header_end = min(header_end, _total_wall_time_index(lines))
+
+    log = LAMMPSLog(path)
+    log.version = _first_line(text)
+    log.header = LAMMPSLogHeader(lines=tuple(lines[:header_end]))
+    log.runs = tuple(
+        _parse_run(index, lines[start:end], start, style)
+        for index, (start, end) in enumerate(run_ranges)
+    )
+    log.total_wall_time = total_wall_time
+    log.warnings = tuple(_collect_warnings(lines, 0, None))
+    log.raw_text = text
+    log.info = {
+        "version": log.version,
+        "n_stages": len(log.legacy_thermo_stages()),
+        "stages": log.legacy_thermo_stages(),
+    }
+    return log
+
+
+def _find_run_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    starts = [idx for idx, line in enumerate(lines) if _MEMORY_RE.match(line.strip())]
+    ranges: list[tuple[int, int]] = []
+    wall_idx = _total_wall_time_index(lines)
+    for idx, start in enumerate(starts):
+        next_start = starts[idx + 1] if idx + 1 < len(starts) else len(lines)
+        end = min(next_start, wall_idx) if wall_idx >= 0 else next_start
+        ranges.append((start, end))
+    return ranges
+
+
+def _parse_run(
+    index: int,
+    lines: list[str],
+    line_offset: int,
+    style: str,
+) -> LAMMPSRun:
+    consumed: set[int] = set()
+    memory = _parse_memory(lines, consumed)
+    loop_idx = _first_index(lines, lambda line: _LOOP_TIME_RE.match(line.strip()))
+    thermo = _parse_thermo(lines, consumed, loop_idx, style)
+    loop_time = _parse_loop_time(lines, consumed)
+    performance = _parse_performance(lines, consumed)
+    CPU_use = _parse_CPU_use(lines, consumed)
+    MPI_task_timing = _parse_timing_breakdown(
+        lines, consumed, "MPI task timing breakdown"
+    )
+    thread_timing = _parse_timing_breakdown(lines, consumed, "Thread timings breakdown")
+    if thread_timing is None:
+        thread_timing = _parse_timing_breakdown(lines, consumed, "Thread timing")
+    load_balance = tuple(_parse_load_balance(lines, consumed))
+    neighbor_statistics = _parse_neighbor_statistics(lines, consumed)
+    warnings = tuple(_collect_warnings(lines, line_offset, index))
+    for idx, line in enumerate(lines):
+        if _WARNING_RE.match(line.strip()):
+            consumed.add(idx)
+
+    setup_log = tuple(
+        line
+        for idx, line in enumerate(lines[: loop_idx if loop_idx >= 0 else 0])
+        if idx not in consumed and line.strip()
+    )
+    unparsed_log = tuple(
+        line
+        for idx, line in enumerate(lines)
+        if idx not in consumed and line.strip() and line not in setup_log
+    )
+
+    return LAMMPSRun(
+        index=index,
+        setup_log=setup_log,
+        memory=memory,
+        thermo=thermo,
+        loop_time=loop_time,
+        performance=performance,
+        CPU_use=CPU_use,
+        MPI_task_timing=MPI_task_timing,
+        thread_timing=thread_timing,
+        load_balance=load_balance,
+        neighbor_statistics=neighbor_statistics,
+        warnings=warnings,
+        unparsed_log=unparsed_log,
+        raw_text="\n".join(lines),
+    )
+
+
+def _parse_memory(lines: list[str], consumed: set[int]) -> LAMMPSMemoryUsage | None:
+    for idx, line in enumerate(lines):
+        match = _MEMORY_RE.match(line.strip())
+        if not match:
+            continue
+        consumed.add(idx)
+        return LAMMPSMemoryUsage(
+            minimum=float(match["minimum"]),
+            average=float(match["average"]),
+            maximum=float(match["maximum"]),
+            units=match["units"],
+            raw_line=line,
+        )
+    return None
+
+
+def _parse_thermo(
+    lines: list[str],
+    consumed: set[int],
+    loop_idx: int,
+    style: str,
+) -> LAMMPSThermo | None:
+    if style != "default" or loop_idx < 0:
+        return None
+
+    start = _first_index(lines, lambda line: _MEMORY_RE.match(line.strip()))
+    if start < 0:
+        start = -1
+    body_indices = [idx for idx in range(start + 1, loop_idx) if lines[idx].strip()]
+    if len(body_indices) < 2:
+        return None
+
+    header_idx = body_indices[0]
+    columns = tuple(lines[header_idx].split())
+    data_indices: list[int] = []
+    for idx in body_indices[1:]:
+        parts = lines[idx].split()
+        if len(parts) != len(columns) or not all(_is_float(part) for part in parts):
+            break
+        data_indices.append(idx)
+
+    if not columns or not data_indices:
+        return None
+
+    dtype = np.dtype({"names": columns, "formats": ["f8"] * len(columns)})
+    try:
+        data = np.loadtxt(
+            [lines[idx] for idx in data_indices],
+            dtype=dtype,
+            ndmin=1,
+        )
+    except ValueError:
+        return None
+
+    consumed.add(header_idx)
+    consumed.update(data_indices)
+    raw_lines = tuple(lines[idx] for idx in [header_idx, *data_indices])
+    return LAMMPSThermo(columns=columns, data=data, raw_lines=raw_lines)
+
+
+def _parse_loop_time(lines: list[str], consumed: set[int]) -> LAMMPSLoopTime | None:
+    for idx, line in enumerate(lines):
+        match = _LOOP_TIME_RE.match(line.strip())
+        if not match:
+            continue
+        consumed.add(idx)
+        return LAMMPSLoopTime(
+            seconds=float(match["seconds"]),
+            procs=int(match["procs"]),
+            steps=_int_or_none(match["steps"]),
+            atoms=_int_or_none(match["atoms"]),
+            raw_line=line,
+        )
+    return None
+
+
+def _parse_performance(
+    lines: list[str],
+    consumed: set[int],
+) -> LAMMPSPerformance | None:
+    for idx, line in enumerate(lines):
+        match = _PERFORMANCE_RE.match(line.strip())
+        if not match:
+            continue
+        consumed.add(idx)
+        return LAMMPSPerformance(
+            ns_per_day=float(match["ns_per_day"]),
+            hours_per_ns=float(match["hours_per_ns"]),
+            timesteps_per_second=float(match["timesteps_per_second"]),
+            atom_steps_per_second=_float_or_none(match["atom_steps_per_second"]),
+            atom_steps_units=match["atom_steps_units"],
+            raw_line=line,
+        )
+    return None
+
+
+def _parse_CPU_use(lines: list[str], consumed: set[int]) -> LAMMPSCPUUse | None:
+    for idx, line in enumerate(lines):
+        match = _CPU_USE_RE.match(line.strip())
+        if not match:
+            continue
+        consumed.add(idx)
+        return LAMMPSCPUUse(
+            percent=float(match["percent"]),
+            MPI_tasks=int(match["MPI_tasks"]),
+            OMP_threads=_int_or_none(match["OMP_threads"]),
+            raw_line=line,
+        )
+    return None
+
+
+def _parse_timing_breakdown(
+    lines: list[str],
+    consumed: set[int],
+    title_prefix: str,
+) -> LAMMPSTimingBreakdown | None:
+    start = _first_index(lines, lambda line: line.strip().startswith(title_prefix))
+    if start < 0:
+        return None
+
+    raw_indices = [start]
+    rows: list[LAMMPSTimingRow] = []
+    for idx in range(start + 1, len(lines)):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped:
+            break
+        row = _parse_timing_row(line)
+        if row is not None:
+            rows.append(row)
+            raw_indices.append(idx)
+            continue
+        if "|" in line or set(stripped) <= {"-"} or stripped.startswith("Section"):
+            raw_indices.append(idx)
+            continue
+        if rows:
+            break
+
+    if not rows:
+        return None
+    consumed.update(raw_indices)
+    return LAMMPSTimingBreakdown(
+        title=lines[start].strip().rstrip(":"),
+        rows=tuple(rows),
+        raw_lines=tuple(lines[idx] for idx in raw_indices),
+    )
+
+
+def _parse_timing_row(line: str) -> LAMMPSTimingRow | None:
+    if "|" not in line:
+        return None
+    parts = [part.strip() for part in line.split("|")]
+    if len(parts) != 6 or not all(_is_float(part) for part in parts[1:]):
+        return None
+    return LAMMPSTimingRow(
+        section=parts[0],
+        min_time=float(parts[1]),
+        avg_time=float(parts[2]),
+        max_time=float(parts[3]),
+        percent_varavg=float(parts[4]),
+        percent_total=float(parts[5]),
+        raw_line=line,
+    )
+
+
+def _parse_load_balance(
+    lines: list[str],
+    consumed: set[int],
+) -> list[LAMMPSLoadBalance]:
+    entries: list[LAMMPSLoadBalance] = []
+    idx = 0
+    while idx < len(lines):
+        match = _LOAD_BALANCE_RE.match(lines[idx].strip())
+        if not match:
+            idx += 1
+            continue
+
+        raw_indices = [idx]
+        histogram: tuple[int, ...] = ()
+        next_idx = idx + 1
+        if next_idx < len(lines) and lines[next_idx].strip().startswith("Histogram:"):
+            histogram = tuple(int(value) for value in lines[next_idx].split()[1:])
+            raw_indices.append(next_idx)
+        consumed.update(raw_indices)
+        entries.append(
+            LAMMPSLoadBalance(
+                name=match["name"],
+                average=float(match["average"]),
+                maximum=float(match["maximum"]),
+                minimum=float(match["minimum"]),
+                histogram=histogram,
+                raw_lines=tuple(lines[line_idx] for line_idx in raw_indices),
+            )
+        )
+        idx = raw_indices[-1] + 1
+    return entries
+
+
+def _parse_neighbor_statistics(
+    lines: list[str],
+    consumed: set[int],
+) -> LAMMPSNeighborStatistics | None:
+    keys = {
+        "Total # of neighbors": ("total_neighbors", int),
+        "Ave neighs/atom": ("ave_neighs_per_atom", float),
+        "Ave special neighs/atom": ("ave_special_neighs_per_atom", float),
+        "Neighbor list builds": ("neighbor_list_builds", int),
+        "Dangerous builds": ("dangerous_builds", int),
+    }
+    values: dict[str, Any] = {
+        "total_neighbors": None,
+        "ave_neighs_per_atom": None,
+        "ave_special_neighs_per_atom": None,
+        "neighbor_list_builds": None,
+        "dangerous_builds": None,
+    }
+    raw_indices: list[int] = []
+    for idx, line in enumerate(lines):
+        if "=" not in line:
+            continue
+        key, raw_value = [part.strip() for part in line.split("=", 1)]
+        if key not in keys:
+            continue
+        field_name, converter = keys[key]
+        values[field_name] = (
+            converter(float(raw_value)) if converter is int else float(raw_value)
+        )
+        raw_indices.append(idx)
+
+    if not raw_indices:
+        return None
+    consumed.update(raw_indices)
+    return LAMMPSNeighborStatistics(
+        total_neighbors=values["total_neighbors"],
+        ave_neighs_per_atom=values["ave_neighs_per_atom"],
+        ave_special_neighs_per_atom=values["ave_special_neighs_per_atom"],
+        neighbor_list_builds=values["neighbor_list_builds"],
+        dangerous_builds=values["dangerous_builds"],
+        raw_lines=tuple(lines[idx] for idx in raw_indices),
+    )
+
+
+def _collect_warnings(
+    lines: list[str],
+    line_offset: int,
+    run_index: int | None,
+) -> list[LAMMPSWarning]:
+    warnings: list[LAMMPSWarning] = []
+    for idx, line in enumerate(lines):
+        match = _WARNING_RE.match(line.strip())
+        if match:
+            warnings.append(
+                LAMMPSWarning(
+                    message=match["message"],
+                    raw_line=line,
+                    line_number=line_offset + idx + 1,
+                    run_index=run_index,
+                )
+            )
+    return warnings
+
+
+def _parse_total_wall_time(lines: list[str]) -> str | None:
+    idx = _total_wall_time_index(lines)
+    if idx < 0:
+        return None
+    return lines[idx].split(":", 1)[1].strip() if ":" in lines[idx] else lines[idx]
+
+
+def _total_wall_time_index(lines: list[str]) -> int:
+    return _first_index(lines, lambda line: line.strip().startswith("Total wall time:"))
+
+
+def _first_index(lines: list[str], predicate) -> int:
+    for idx, line in enumerate(lines):
+        if predicate(line):
+            return idx
+    return -1
+
+
+def _first_line(text: str) -> str | None:
+    line = text.splitlines()[0] if text.splitlines() else None
+    return line
+
+
+def _is_float(value: str) -> bool:
+    try:
+        float(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _float_or_none(value: str | None) -> float | None:
+    return float(value) if value is not None else None
+
+
+def _int_or_none(value: str | None) -> int | None:
+    return int(value) if value is not None else None
+
+
+def _array_rows(array: np.ndarray) -> list[list[float]]:
+    if array.dtype.names:
+        return [[float(value) for value in record] for record in array.tolist()]
+    return np.asarray(array).astype(float).tolist()
+
+
+def _dataclass_to_dict(obj: Any) -> dict[str, Any]:
+    return {field.name: _jsonify(getattr(obj, field.name)) for field in fields(obj)}
+
+
+def _jsonify(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return _array_rows(value)
+    if is_dataclass(value):
+        if hasattr(value, "to_dict"):
+            return value.to_dict()
+        return _dataclass_to_dict(value)
+    if isinstance(value, tuple):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    return value

--- a/src/molpy/io/readers.py
+++ b/src/molpy/io/readers.py
@@ -6,7 +6,10 @@ All functions return Frame objects by populating an optional frame parameter.
 """
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .log.lammps import LAMMPSLog
 
 PathLike = str | Path
 
@@ -373,3 +376,23 @@ def read_h5_trajectory(file: PathLike) -> Any:
     from .trajectory.h5 import HDF5TrajectoryReader
 
     return HDF5TrajectoryReader(Path(file))
+
+
+# =============================================================================
+# Log Readers
+# =============================================================================
+
+
+def read_LAMMPS_log(file: PathLike) -> "LAMMPSLog":
+    """
+    Read a LAMMPS log file and return a nested dataclass result.
+
+    Args:
+        file: Path to LAMMPS log file
+
+    Returns:
+        Parsed ``LAMMPSLog`` object.
+    """
+    from .log.lammps import read_LAMMPS_log as _read_LAMMPS_log
+
+    return _read_LAMMPS_log(Path(file))

--- a/src/molpy/version.py
+++ b/src/molpy/version.py
@@ -4,8 +4,8 @@ Version information for MolPy.
 This module provides simple version information for MolPy.
 """
 
-version = "0.3.2"
-release_date = "2026-04-29"
+version = "0.3.3"
+release_date = "2026-05-11"
 
 
 def __str__() -> str:

--- a/tests/test_compute/test_box_inheritance.py
+++ b/tests/test_compute/test_box_inheritance.py
@@ -1,0 +1,54 @@
+"""molpy.Box inherits from molrs.Box and is interchangeable with it.
+
+Acceptance criteria covered:
+- molpy-box-is-a-molrs-box (Phase 1)
+- molpy-box-public-api-preserved (Phase 1, partial — full API is in
+  test_core/test_box.py)
+"""
+
+import numpy as np
+import pytest
+
+import molpy
+import molrs
+
+
+class TestMolpyBoxInheritsFromMolrsBox:
+    """Critical contract: molpy.Box is-a molrs.Box."""
+
+    def test_molpy_box_is_a_molrs_box(self):
+        b = molpy.Box.cubic(10.0)
+        assert isinstance(b, molrs.Box)
+        assert isinstance(b, molpy.Box)
+
+    def test_molpy_box_keeps_molpy_api(self):
+        b = molpy.Box.cubic(10.0)
+        # molpy-style read-through.
+        assert b.lx == pytest.approx(10.0)
+        assert b.ly == pytest.approx(10.0)
+        assert b.lz == pytest.approx(10.0)
+        assert b.style == molpy.Box.Style.ORTHOGONAL
+        assert b.matrix.shape == (3, 3)
+        assert b.matrix[0, 0] == pytest.approx(10.0)
+        np.testing.assert_array_equal(b.pbc, np.array([True, True, True]))
+
+
+class TestFrameBoxPassesDirectlyToMolrs:
+    """frame.box must be accepted by molrs APIs without conversion."""
+
+    def test_neighbor_query_accepts_frame_box_directly(self):
+        frame = molpy.Frame()
+        frame.box = molpy.Box.cubic(10.0)
+        rng = np.random.default_rng(0)
+        xyz = rng.uniform(0.0, 10.0, size=(50, 3))
+        # No adapter: pass molpy frame.box straight into molrs.
+        nq = molrs.NeighborQuery(frame.box, xyz, 2.0)
+        nlist = nq.query_self()
+        assert nlist.n_pairs >= 0  # "no exception, returns nlist" check
+
+    def test_molrs_volume_method_works_on_molpy_box(self):
+        b = molpy.Box.cubic(10.0)
+        # molrs.Box.volume() is a method; molpy.Box.volume is a property.
+        # Both must coexist via MRO override (subclass property wins for
+        # bare attribute access; super().volume() still callable).
+        assert b.volume == pytest.approx(1000.0)  # molpy property

--- a/tests/test_compute/test_neighborlist.py
+++ b/tests/test_compute/test_neighborlist.py
@@ -1,0 +1,78 @@
+"""molpy.compute.NeighborList — molrs-backed spatial neighbor list.
+
+Acceptance criteria covered:
+- compute-neighborlist-class-exposed
+- neighborlist-parity-with-molrs
+- input-frame-immutable
+"""
+
+import numpy as np
+import pytest
+
+import molpy
+import molrs
+from molpy.compute import NeighborList
+from molpy.compute.base import Compute
+
+
+def _make_random_frame(n: int = 200, box_len: float = 10.0, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    xyz = rng.uniform(0.0, box_len, size=(n, 3))
+    frame = molpy.Frame()
+    frame["atoms"] = {"x": xyz[:, 0], "y": xyz[:, 1], "z": xyz[:, 2]}
+    frame.box = molpy.Box.cubic(box_len)
+    return frame, xyz
+
+
+def test_neighborlist_is_a_compute_subclass():
+    assert issubclass(NeighborList, Compute)
+
+
+def test_basic_periodic():
+    frame, _ = _make_random_frame()
+    nlist = NeighborList(cutoff=2.0)(frame)
+    assert nlist.n_pairs > 0
+    distances = np.asarray(nlist.distances)
+    assert (distances <= 2.0).all()
+    assert (distances >= 0.0).all()
+
+
+def test_parity_with_molrs_direct():
+    """molpy.compute.NeighborList must produce the same pairs as a direct
+    molrs.NeighborQuery call on the same inputs.
+    """
+    frame, xyz = _make_random_frame(seed=42)
+
+    via_molpy = NeighborList(cutoff=2.5)(frame)
+    via_molrs = molrs.NeighborQuery(frame.box, xyz, 2.5).query_self()
+
+    assert via_molpy.n_pairs == via_molrs.n_pairs
+    np.testing.assert_array_equal(
+        np.sort(via_molpy.distances), np.sort(via_molrs.distances)
+    )
+
+
+def test_input_frame_immutable():
+    frame, xyz = _make_random_frame(seed=7)
+    box_matrix_before = frame.box.matrix.copy()
+    x_before = frame["atoms"]["x"].copy()
+    y_before = frame["atoms"]["y"].copy()
+    z_before = frame["atoms"]["z"].copy()
+    pbc_before = frame.box.pbc.copy()
+
+    NeighborList(cutoff=3.0)(frame)
+
+    np.testing.assert_array_equal(frame.box.matrix, box_matrix_before)
+    np.testing.assert_array_equal(frame["atoms"]["x"], x_before)
+    np.testing.assert_array_equal(frame["atoms"]["y"], y_before)
+    np.testing.assert_array_equal(frame["atoms"]["z"], z_before)
+    np.testing.assert_array_equal(frame.box.pbc, pbc_before)
+
+
+def test_distances_within_cutoff():
+    """Spot-check: every reported pair distance ≤ cutoff."""
+    frame, _ = _make_random_frame(n=500, seed=1)
+    cutoff = 1.8
+    nlist = NeighborList(cutoff=cutoff)(frame)
+    distances = np.asarray(nlist.distances)
+    assert (distances <= cutoff + 1e-10).all()

--- a/tests/test_compute/test_rdf.py
+++ b/tests/test_compute/test_rdf.py
@@ -1,0 +1,96 @@
+"""molpy.compute.RDF — molrs-backed g(r).
+
+Acceptance criteria covered:
+- compute-rdf-class-exposed
+- rdf-ideal-gas-correct
+- input-frame-immutable
+- rdf-requires-box
+"""
+
+import numpy as np
+import pytest
+
+import molpy
+from molpy.compute import RDF, NeighborList
+from molpy.compute.base import Compute
+
+
+def _uniform_frame(n: int, box_len: float, seed: int):
+    rng = np.random.default_rng(seed)
+    xyz = rng.uniform(0.0, box_len, size=(n, 3))
+    frame = molpy.Frame()
+    frame["atoms"] = {"x": xyz[:, 0], "y": xyz[:, 1], "z": xyz[:, 2]}
+    frame.box = molpy.Box.cubic(box_len)
+    return frame
+
+
+def test_rdf_is_a_compute_subclass():
+    assert issubclass(RDF, Compute)
+
+
+def test_ideal_gas_g_of_r_approaches_one():
+    """For a uniform random point cloud, g(r) → 1 in middle bins."""
+    n_frames = 5
+    n_points = 2000
+    box_len = 30.0
+    cutoff = 8.0
+
+    frames = [_uniform_frame(n_points, box_len, seed=i) for i in range(n_frames)]
+    nlists = [NeighborList(cutoff=cutoff)(f) for f in frames]
+
+    rdf = RDF(n_bins=40, r_max=cutoff, r_min=0.0)
+    result = rdf(frames, nlists)
+
+    g_of_r = np.asarray(result.rdf)
+    centers = np.asarray(result.bin_centers)
+
+    # Middle bins (skip the first few near r=0 where statistics are poor and
+    # the last few near r_max where shells extend outside the box).
+    middle = (centers > 2.0) & (centers < cutoff - 1.0)
+    g_middle = g_of_r[middle]
+    assert ((g_middle > 0.7) & (g_middle < 1.3)).all(), (
+        f"middle-bin g(r) outside [0.7, 1.3]: {g_middle}"
+    )
+
+
+def test_multi_frame_aggregation():
+    """g(r) computed over a list of frames matches per-frame averaging."""
+    box_len = 20.0
+    cutoff = 6.0
+    n_bins = 30
+
+    frames = [_uniform_frame(800, box_len, seed=i) for i in range(3)]
+    nlists = [NeighborList(cutoff=cutoff)(f) for f in frames]
+
+    multi = RDF(n_bins, r_max=cutoff)(frames, nlists)
+    g_multi = np.asarray(multi.rdf)
+
+    # Sanity: shape + finite + non-negative.
+    assert g_multi.shape == (n_bins,)
+    assert np.isfinite(g_multi).all()
+    assert (g_multi >= 0.0).all()
+
+
+def test_input_frame_immutable():
+    frame = _uniform_frame(300, 15.0, seed=11)
+    nlist = NeighborList(cutoff=4.0)(frame)
+
+    box_matrix_before = frame.box.matrix.copy()
+    x_before = frame["atoms"]["x"].copy()
+
+    RDF(20, r_max=4.0)([frame], [nlist])
+
+    np.testing.assert_array_equal(frame.box.matrix, box_matrix_before)
+    np.testing.assert_array_equal(frame["atoms"]["x"], x_before)
+
+
+def test_no_box_raises():
+    """RDF on a frame without a box must raise ValueError mentioning 'box'."""
+    frame = molpy.Frame()
+    rng = np.random.default_rng(0)
+    xyz = rng.uniform(0.0, 10.0, size=(50, 3))
+    frame["atoms"] = {"x": xyz[:, 0], "y": xyz[:, 1], "z": xyz[:, 2]}
+    # frame.box left as None deliberately.
+
+    with pytest.raises(ValueError, match="box"):
+        NeighborList(cutoff=2.0)(frame)

--- a/tests/test_core/test_box.py
+++ b/tests/test_core/test_box.py
@@ -63,8 +63,11 @@ class TestBoxProperties:
         npt.assert_allclose(box.ly, 4)
         npt.assert_allclose(box.lz, 5)
         npt.assert_allclose(box.l_inv, [0.5, 0.25, 0.2])
-        box.xy = 2
-        npt.assert_allclose(box.xy, 2)
+        # tilts come back exactly as constructed (xy=1, xz=0, yz=0)
+        npt.assert_allclose(box.tilts, [1, 0, 0])
+        # Box is immutable post-molrs-inheritance — construct a new Box to change xy.
+        rebuilt = Box.tric([2, 4, 5], [2, 0, 0])
+        npt.assert_allclose(rebuilt.xy, 2)
 
     def test_bounds_and_volume(self):
         box = Box.orth([2, 3, 4])
@@ -76,10 +79,14 @@ class TestBoxProperties:
     def test_periodic_flags(self):
         box = Box.orth([1, 2, 3])
         assert box.periodic
-        box.periodic_x = False
-        assert not box.periodic
-        box.periodic = True
-        assert box.periodic
+        # Box is immutable; build new boxes for non-default PBC.
+        non_x = Box.orth([1, 2, 3], pbc=[False, True, True])
+        assert not non_x.periodic
+        assert not non_x.periodic_x
+        assert non_x.periodic_y
+        assert non_x.periodic_z
+        all_on = Box.orth([1, 2, 3], pbc=[True, True, True])
+        assert all_on.periodic
 
 
 class TestBoxOps:

--- a/tests/test_core/test_cg.py
+++ b/tests/test_core/test_cg.py
@@ -1,26 +1,70 @@
 """
 Test CoarseGrain class API for creating and managing coarse-grained structures.
 
-Tests the CoarseGrain system including:
-- Bead and CGBond entity/link classes
-- Factory methods (def_*) and add methods (add_*)
-- Batch operations
-- Spatial transformations
-- System composition
-- Bidirectional conversion with Atomistic
+Tests the redesigned CG module per spec
+``docs/specs/cg-atomistic-mapping-redesign.md``:
+
+- ``Bead`` is a structurally empty :class:`Entity` (no mandatory fields).
+- ``bead["atoms"]`` is a soft convention key (``tuple[Atom, ...]``); MolPy
+  neither enforces nor writes it.
+- ``CGBond`` is a two-endpoint :class:`Link` between two beads.
+- ``CoarseGrain`` mirrors :class:`Atomistic` plus the single extra method
+  :meth:`CoarseGrain.beads_of` for reverse lookup.
+- No ``from_atomistic`` / ``to_atomistic`` / ``Bead.atomistic`` field.
 """
+
+import copy
 
 import numpy as np
 import pytest
 
-from molpy import Atomistic, Bead, CGBond, CoarseGrain
+from molpy.core.atomistic import Atomistic
+from molpy.core.cg import Bead, CGBond, CoarseGrain
+
+
+# ---------------------------------------------------------------------------
+# Bead — structurally empty Entity
+# ---------------------------------------------------------------------------
 
 
 class TestBeadEntity:
-    """Test Bead entity class."""
+    """Test Bead entity class — no required fields, dict-like."""
+
+    def test_bead_is_empty_entity(self):
+        """Bead() is creatable with zero arguments and has no required keys."""
+        bead = Bead()
+
+        assert isinstance(bead, Bead)
+        # The underlying data dict starts empty.
+        assert dict(bead) == {}
+
+    def test_bead_dict_interface(self):
+        """Bead exposes attributes through the dict interface."""
+        bead = Bead(type="A", x=1.0)
+
+        assert bead["type"] == "A"
+        assert bead["x"] == 1.0
+
+    def test_bead_deepcopy_produces_independent_object(self):
+        """Default Python deepcopy semantics apply: the clone is a separate
+        Bead with an independent dict. Bead has no custom ``__deepcopy__``
+        and therefore makes no opinion about which conventional keys
+        should be shared vs. cloned — that's the user's call."""
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C", x=0.0, y=0.0, z=0.0)
+        b = ato.def_atom(symbol="H", x=1.0, y=0.0, z=0.0)
+
+        bead = Bead(atoms=(a, b), type="CH")
+        clone = copy.deepcopy(bead)
+
+        assert clone is not bead
+        assert clone["type"] == "CH"
+        # dict is independent: mutating the clone does not affect the original
+        clone["type"] = "MUTATED"
+        assert bead["type"] == "CH"
 
     def test_create_bead_with_attributes(self):
-        """Test creating a bead with attributes."""
+        """Beads carry arbitrary attributes via kwargs."""
         bead = Bead(type="PEO", x=1.0, y=2.0, z=3.0)
 
         assert isinstance(bead, Bead)
@@ -29,37 +73,22 @@ class TestBeadEntity:
         assert bead.get("y") == 2.0
         assert bead.get("z") == 3.0
 
-    def test_bead_repr_with_type(self):
-        """Test bead string representation shows type."""
+    def test_bead_repr_contains_class_name(self):
+        """Bead repr identifies the class."""
         bead = Bead(type="PEO")
-        repr_str = repr(bead)
+        assert "Bead" in repr(bead)
 
-        assert "Bead" in repr_str
-        assert "PEO" in repr_str
 
-    def test_bead_repr_with_name(self):
-        """Test bead string representation shows name if no type."""
-        bead = Bead(name="BeadA")
-        repr_str = repr(bead)
-
-        assert "Bead" in repr_str
-        assert "BeadA" in repr_str
-
-    def test_bead_with_atomistic_mapping(self):
-        """Test bead can store atomistic structure as member."""
-        atomistic = Atomistic()
-        atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-
-        bead = Bead(atomistic=atomistic, type="CH3")
-
-        assert bead.atomistic is atomistic
+# ---------------------------------------------------------------------------
+# CGBond — two-endpoint Link
+# ---------------------------------------------------------------------------
 
 
 class TestCGBondLink:
     """Test CGBond link class."""
 
     def test_create_cgbond(self):
-        """Test creating a CGBond between two beads."""
+        """Create a CGBond between two beads with attributes."""
         bead1 = Bead(type="A")
         bead2 = Bead(type="B")
 
@@ -70,8 +99,8 @@ class TestCGBondLink:
         assert bond.jbead is bead2
         assert bond.get("type") == "harmonic"
 
-    def test_cgbond_endpoint_properties(self):
-        """Test CGBond ibead and jbead properties."""
+    def test_cgbond_endpoints(self):
+        """CGBond.ibead / .jbead expose the endpoints in order."""
         bead1 = Bead(type="A")
         bead2 = Bead(type="B")
         bond = CGBond(bead1, bead2)
@@ -80,16 +109,15 @@ class TestCGBondLink:
         assert bond.jbead is bead2
 
     def test_cgbond_repr(self):
-        """Test CGBond string representation."""
+        """CGBond repr identifies the class."""
         bead1 = Bead(type="A")
         bead2 = Bead(type="B")
         bond = CGBond(bead1, bead2)
 
-        repr_str = repr(bond)
-        assert "CGBond" in repr_str
+        assert "CGBond" in repr(bond)
 
     def test_cgbond_requires_beads(self):
-        """Test CGBond validates bead types."""
+        """CGBond rejects non-Bead endpoints."""
         bead = Bead(type="A")
         not_a_bead = object()
 
@@ -97,21 +125,26 @@ class TestCGBondLink:
             CGBond(bead, not_a_bead)
 
 
-class TestCoarseGrainFactoryMethods:
-    """Test def_* factory methods that create and add entities."""
+# ---------------------------------------------------------------------------
+# def_bead / def_cgbond registration — parallel to Atomistic.def_atom / def_bond
+# ---------------------------------------------------------------------------
 
-    def test_def_bead_creates_and_adds(self):
-        """Test def_bead creates a Bead and adds it to the structure."""
+
+class TestCoarseGrainFactoryMethods:
+    """Test def_* factory methods that create and register entities."""
+
+    def test_def_bead_registers_in_entities(self):
+        """def_bead returns the new Bead and it appears in ``cg.beads``."""
         cg = CoarseGrain()
         bead = cg.def_bead(type="PEO", x=0, y=0, z=0)
 
         assert isinstance(bead, Bead)
         assert bead.get("type") == "PEO"
         assert len(cg.beads) == 1
-        assert next(iter(cg.beads)) is bead
+        assert bead in cg.beads
 
-    def test_def_cgbond_creates_and_adds(self):
-        """Test def_cgbond creates a CGBond between two beads."""
+    def test_def_cgbond_registers_in_links(self):
+        """def_cgbond creates a CGBond between two beads and registers it."""
         cg = CoarseGrain()
         b1 = cg.def_bead(type="A")
         b2 = cg.def_bead(type="B")
@@ -123,13 +156,14 @@ class TestCoarseGrainFactoryMethods:
         assert bond.jbead is b2
         assert bond.get("type") == "harmonic"
         assert len(cg.cgbonds) == 1
+        assert bond in cg.cgbonds
 
 
 class TestCoarseGrainAddMethods:
-    """Test add_* methods that add existing entity objects."""
+    """Test add_* methods that register pre-built entity objects."""
 
     def test_add_bead_adds_existing(self):
-        """Test add_bead adds an already created Bead object."""
+        """add_bead registers an already-constructed Bead."""
         cg = CoarseGrain()
         bead = Bead(type="PEO", x=0, y=0, z=0)
 
@@ -140,7 +174,7 @@ class TestCoarseGrainAddMethods:
         assert next(iter(cg.beads)) is bead
 
     def test_add_cgbond_adds_existing(self):
-        """Test add_cgbond adds an already created CGBond object."""
+        """add_cgbond registers an already-constructed CGBond."""
         cg = CoarseGrain()
         b1 = cg.def_bead(type="A")
         b2 = cg.def_bead(type="B")
@@ -157,7 +191,7 @@ class TestCoarseGrainBatchMethods:
     """Test batch operations for creating and adding multiple entities."""
 
     def test_def_beads_batch_create(self):
-        """Test def_beads creates multiple beads at once."""
+        """def_beads creates multiple beads at once."""
         cg = CoarseGrain()
 
         beads = cg.def_beads(
@@ -174,7 +208,7 @@ class TestCoarseGrainBatchMethods:
         assert np.array_equal(cg.beads["type"], ["PEO", "PMA", "PEO"])
 
     def test_def_cgbonds_batch_create(self):
-        """Test def_cgbonds creates multiple bonds at once."""
+        """def_cgbonds creates multiple bonds at once."""
         cg = CoarseGrain()
         b1 = cg.def_bead(type="A")
         b2 = cg.def_bead(type="B")
@@ -192,7 +226,7 @@ class TestCoarseGrainBatchMethods:
         assert len(cg.cgbonds) == 2
 
     def test_add_beads_batch_add(self):
-        """Test add_beads adds multiple existing Bead objects."""
+        """add_beads adds multiple existing Bead objects."""
         cg = CoarseGrain()
         beads = [
             Bead(type="A", x=0, y=0, z=0),
@@ -205,7 +239,7 @@ class TestCoarseGrainBatchMethods:
         assert len(cg.beads) == 2
 
     def test_add_cgbonds_batch_add(self):
-        """Test add_cgbonds adds multiple existing CGBond objects."""
+        """add_cgbonds adds multiple existing CGBond objects."""
         cg = CoarseGrain()
         b1 = cg.def_bead(type="A")
         b2 = cg.def_bead(type="B")
@@ -222,11 +256,81 @@ class TestCoarseGrainBatchMethods:
         assert len(cg.cgbonds) == 2
 
 
+# ---------------------------------------------------------------------------
+# beads_of — the single extra core method (reverse lookup)
+# ---------------------------------------------------------------------------
+
+
+class TestBeadsOf:
+    """Test ``CoarseGrain.beads_of(atom)`` reverse lookup over the conventional
+    ``bead["atoms"]`` key."""
+
+    def test_beads_of_disjoint(self):
+        """In a disjoint partition each atom maps to exactly one bead."""
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C", x=0, y=0, z=0)
+        b = ato.def_atom(symbol="O", x=5, y=0, z=0)
+
+        cg = CoarseGrain()
+        bead_a = cg.def_bead(atoms=(a,), type="A")
+        bead_b = cg.def_bead(atoms=(b,), type="B")
+
+        assert cg.beads_of(a) == (bead_a,)
+        assert cg.beads_of(b) == (bead_b,)
+
+    def test_beads_of_overlap(self):
+        """An atom shared by two beads is returned in both."""
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C", x=0, y=0, z=0)
+        b = ato.def_atom(symbol="O", x=5, y=0, z=0)
+        c = ato.def_atom(symbol="N", x=10, y=0, z=0)
+
+        cg = CoarseGrain()
+        bead1 = cg.def_bead(atoms=(a, b), type="AB")
+        bead2 = cg.def_bead(atoms=(b, c), type="BC")
+
+        result = cg.beads_of(b)
+
+        assert len(result) == 2
+        assert bead1 in result
+        assert bead2 in result
+
+    def test_beads_of_unknown_returns_empty(self):
+        """Unknown atom (not in any bead's ``atoms`` key) gives an empty tuple."""
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C", x=0, y=0, z=0)
+        unknown = ato.def_atom(symbol="X", x=99, y=0, z=0)
+
+        cg = CoarseGrain()
+        cg.def_bead(atoms=(a,), type="A")
+
+        assert cg.beads_of(unknown) == ()
+
+    def test_beads_of_skips_beads_without_atoms_key(self):
+        """Beads lacking an ``atoms`` key are silently skipped (not errors)."""
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C", x=0, y=0, z=0)
+
+        cg = CoarseGrain()
+        # Bead with no AA precursor (pure CG bead)
+        cg.def_bead(type="pure_cg", x=0, y=0, z=0)
+        bead_with_atoms = cg.def_bead(atoms=(a,), type="mapped")
+
+        result = cg.beads_of(a)
+
+        assert result == (bead_with_atoms,)
+
+
+# ---------------------------------------------------------------------------
+# Spatial / composition — parallel to Atomistic
+# ---------------------------------------------------------------------------
+
+
 class TestCoarseGrainSpatialOperations:
     """Test spatial transformation operations."""
 
-    def test_move_translates_beads(self):
-        """Test move translates all bead positions."""
+    def test_move_translates_bead_xyz(self):
+        """move() translates all bead positions via the SpatialMixin."""
         cg = CoarseGrain()
         cg.def_bead(type="A", x=0, y=0, z=0)
         cg.def_bead(type="B", x=1, y=0, z=0)
@@ -238,24 +342,22 @@ class TestCoarseGrainSpatialOperations:
         assert np.allclose(positions_x, [5, 6])
 
     def test_spatial_operations_chain(self):
-        """Test spatial operations can be chained."""
+        """move/scale chain and return self."""
         cg = CoarseGrain()
         cg.def_bead(type="A", x=0, y=0, z=0)
 
-        # Chain multiple operations
         result = cg.move([1, 0, 0]).scale(2.0).move([0, 5, 0])
 
         assert result is cg
-        # Verify position changed
         bead = list(cg.beads)[0]
         assert bead.get("x") != 0 or bead.get("y") != 0
 
 
 class TestCoarseGrainSystemComposition:
-    """Test system composition operations."""
+    """Test system composition operations (merge / replicate / select)."""
 
-    def test_iadd_merges_in_place(self):
-        """Test += operator merges structures in place."""
+    def test_merge_two_coarsegrain(self):
+        """``+=`` merges another CoarseGrain in place."""
         cg1 = CoarseGrain()
         cg1.def_bead(type="A", x=0, y=0, z=0)
 
@@ -268,7 +370,7 @@ class TestCoarseGrainSystemComposition:
         assert len(cg1.beads) == 2
 
     def test_add_creates_new_structure(self):
-        """Test + operator creates new merged structure."""
+        """``+`` returns a new merged CoarseGrain, leaving inputs unchanged."""
         cg1 = CoarseGrain()
         cg1.def_bead(type="A", x=0, y=0, z=0)
 
@@ -280,11 +382,11 @@ class TestCoarseGrainSystemComposition:
         assert cg3 is not cg1
         assert cg3 is not cg2
         assert len(cg3.beads) == 2
-        assert len(cg1.beads) == 1  # Original unchanged
-        assert len(cg2.beads) == 1  # Original unchanged
+        assert len(cg1.beads) == 1
+        assert len(cg2.beads) == 1
 
-    def test_replicate_creates_copies(self):
-        """Test replicate creates multiple copies."""
+    def test_replicate_creates_n_copies(self):
+        """replicate(n, transform) makes n copies, original untouched."""
         cg = CoarseGrain()
         cg.def_bead(type="A", x=0, y=0, z=0)
 
@@ -293,8 +395,23 @@ class TestCoarseGrainSystemComposition:
         assert len(result.beads) == 5
         assert len(cg.beads) == 1  # Original unchanged
 
+    def test_select_returns_new_coarsegrain_with_filtered_beads(self):
+        """select(predicate) returns a new CG containing only matching beads."""
+        cg = CoarseGrain()
+        cg.def_bead(type="A", x=0, y=0, z=0)
+        cg.def_bead(type="B", x=1, y=0, z=0)
+        cg.def_bead(type="A", x=2, y=0, z=0)
+
+        sub = cg.select(lambda b: b.get("type") == "A")
+
+        assert sub is not cg
+        assert isinstance(sub, CoarseGrain)
+        assert len(sub.beads) == 2
+        # original is preserved (immutability)
+        assert len(cg.beads) == 3
+
     def test_len_returns_bead_count(self):
-        """Test len() returns number of beads."""
+        """``len(cg)`` is the bead count."""
         cg = CoarseGrain()
         assert len(cg) == 0
 
@@ -305,7 +422,7 @@ class TestCoarseGrainSystemComposition:
         assert len(cg) == 2
 
     def test_repr_shows_structure_summary(self):
-        """Test repr shows bead and bond counts."""
+        """repr summarises bead and bond counts."""
         cg = CoarseGrain()
         cg.def_bead(type="PEO")
         cg.def_bead(type="PMA")
@@ -316,163 +433,16 @@ class TestCoarseGrainSystemComposition:
         assert "2 beads" in repr_str
 
 
-class TestToAtomisticConversion:
-    """Test CoarseGrain to Atomistic conversion."""
-
-    def test_convert_unmapped_beads_to_atoms(self):
-        """Test beads without atomistic mapping create single atoms."""
-        cg = CoarseGrain()
-        cg.def_bead(type="A", x=0, y=0, z=0)
-        cg.def_bead(type="B", x=5, y=0, z=0)
-
-        atomistic = cg.to_atomistic()
-
-        assert len(atomistic.atoms) == 2
-        atoms = list(atomistic.atoms)
-        assert atoms[0].get("element") == "A"
-        assert atoms[1].get("element") == "B"
-
-    def test_convert_mapped_beads_to_atomistic(self):
-        """Test beads with atomistic mapping expand to full structure."""
-        # Create atomistic structure for bead
-        atom_struct = Atomistic()
-        atom_struct.def_atom(symbol="C", x=0, y=0, z=0)
-        atom_struct.def_atom(symbol="H", x=1, y=0, z=0)
-
-        cg = CoarseGrain()
-        bead = cg.def_bead(atomistic=atom_struct, type="CH2", x=0, y=0, z=0)
-
-        atomistic = cg.to_atomistic()
-
-        assert len(atomistic.atoms) == 2
-
-    def test_convert_cgbonds_to_atomistic_bonds(self):
-        """Test CGBonds are converted to atomistic bonds."""
-        cg = CoarseGrain()
-        b1 = cg.def_bead(type="A", x=0, y=0, z=0)
-        b2 = cg.def_bead(type="B", x=5, y=0, z=0)
-        cg.def_cgbond(b1, b2)
-
-        atomistic = cg.to_atomistic()
-
-        assert len(atomistic.bonds) == 1
-
-
-class TestFromAtomisticConversion:
-    """Test Atomistic to CoarseGrain conversion."""
-
-    def test_convert_atomistic_with_mask(self):
-        """Test creating CG from atomistic with bead mask."""
-        # Create simple atomistic structure
-        atomistic = Atomistic()
-        atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-        atomistic.def_atom(symbol="H", x=1, y=0, z=0)
-        atomistic.def_atom(symbol="H", x=0, y=1, z=0)
-
-        # All atoms in one bead
-        mask = np.array([0, 0, 0])
-
-        cg = CoarseGrain.from_atomistic(atomistic, mask)
-
-        assert len(cg.beads) == 1
-        bead = list(cg.beads)[0]
-        assert bead.atomistic is not None
-
-    def test_convert_creates_multiple_beads(self):
-        """Test conversion creates multiple beads from mask."""
-        atomistic = Atomistic()
-        atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-        atomistic.def_atom(symbol="H", x=1, y=0, z=0)
-        atomistic.def_atom(symbol="O", x=5, y=0, z=0)
-        atomistic.def_atom(symbol="H", x=6, y=0, z=0)
-
-        # Two beads: [0,1] and [2,3]
-        mask = np.array([0, 0, 1, 1])
-
-        cg = CoarseGrain.from_atomistic(atomistic, mask)
-
-        assert len(cg.beads) == 2
-
-    def test_bead_position_is_center_of_mass(self):
-        """Test bead position is calculated as center of atoms."""
-        atomistic = Atomistic()
-        atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-        atomistic.def_atom(symbol="H", x=2, y=0, z=0)
-
-        mask = np.array([0, 0])
-
-        cg = CoarseGrain.from_atomistic(atomistic, mask)
-
-        bead = list(cg.beads)[0]
-        # Center should be at (1, 0, 0)
-        assert np.isclose(bead.get("x"), 1.0)
-        assert np.isclose(bead.get("y"), 0.0)
-        assert np.isclose(bead.get("z"), 0.0)
-
-    def test_infer_cgbonds_from_atomistic_bonds(self):
-        """Test CGBonds are inferred from atomistic bonds crossing beads."""
-        atomistic = Atomistic()
-        a1 = atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-        a2 = atomistic.def_atom(symbol="H", x=1, y=0, z=0)
-        a3 = atomistic.def_atom(symbol="O", x=5, y=0, z=0)
-        a4 = atomistic.def_atom(symbol="H", x=6, y=0, z=0)
-
-        # Bond within bead 0
-        atomistic.def_bond(a1, a2)
-        # Bond crossing beads
-        atomistic.def_bond(a2, a3)
-        # Bond within bead 1
-        atomistic.def_bond(a3, a4)
-
-        mask = np.array([0, 0, 1, 1])
-
-        cg = CoarseGrain.from_atomistic(atomistic, mask)
-
-        # Should create one CGBond between the two beads
-        assert len(cg.cgbonds) == 1
-
-    def test_mask_length_validation(self):
-        """Test error when mask length doesn't match atom count."""
-        atomistic = Atomistic()
-        atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-
-        mask = np.array([0, 1])  # Wrong length
-
-        with pytest.raises(ValueError, match="must match number of atoms"):
-            CoarseGrain.from_atomistic(atomistic, mask)
-
-
-class TestRoundTripConversion:
-    """Test bidirectional conversion between Atomistic and CoarseGrain."""
-
-    def test_round_trip_preserves_structure(self):
-        """Test converting atomistic -> CG -> atomistic preserves connectivity."""
-        # Create atomistic structure
-        atomistic = Atomistic()
-        a1 = atomistic.def_atom(symbol="C", x=0, y=0, z=0)
-        a2 = atomistic.def_atom(symbol="H", x=1, y=0, z=0)
-        a3 = atomistic.def_atom(symbol="O", x=5, y=0, z=0)
-        atomistic.def_bond(a1, a2)
-        atomistic.def_bond(a2, a3)
-
-        # Convert to CG
-        mask = np.array([0, 0, 1])
-        cg = CoarseGrain.from_atomistic(atomistic, mask)
-
-        # Convert back to atomistic
-        atomistic2 = cg.to_atomistic()
-
-        # Should have same number of atoms (from mapped structures)
-        assert len(atomistic2.atoms) == 3
-        # Should preserve connectivity
-        assert len(atomistic2.bonds) >= 1
+# ---------------------------------------------------------------------------
+# Generality / arbitrary attrs
+# ---------------------------------------------------------------------------
 
 
 class TestGeneralImplementation:
     """Test that implementation is general without hardcoding."""
 
     def test_arbitrary_bead_types(self):
-        """Test system works with arbitrary bead type names."""
+        """Bead types are free-form labels."""
         cg = CoarseGrain()
         cg.def_bead(type="CustomType1")
         cg.def_bead(type="AnotherType")
@@ -481,7 +451,7 @@ class TestGeneralImplementation:
         assert len(cg.beads) == 3
 
     def test_arbitrary_bond_attributes(self):
-        """Test CGBonds support arbitrary attributes."""
+        """CGBonds support arbitrary attributes."""
         cg = CoarseGrain()
         b1 = cg.def_bead(type="A")
         b2 = cg.def_bead(type="B")
@@ -495,7 +465,7 @@ class TestGeneralImplementation:
         assert bond.get("another_field") == [1, 2, 3]
 
     def test_arbitrary_bead_attributes(self):
-        """Test beads support arbitrary attributes."""
+        """Beads support arbitrary attributes."""
         cg = CoarseGrain()
         bead = cg.def_bead(
             type="Custom", mass=50.0, charge=-1.5, metadata={"key": "value"}
@@ -504,6 +474,231 @@ class TestGeneralImplementation:
         assert bead.get("mass") == 50.0
         assert bead.get("charge") == -1.5
         assert bead.get("metadata") == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# Coverage fill-in — repr branches, edit/select error paths, spatial chaining
+# ---------------------------------------------------------------------------
+
+
+class TestBeadReprFallbacks:
+    """Bead.__repr__ branches when ``type`` is absent."""
+
+    def test_repr_uses_name_when_type_missing(self):
+        bead = Bead(name="POPC")
+        assert "POPC" in repr(bead)
+        assert "Bead" in repr(bead)
+
+    def test_repr_falls_back_to_id_when_type_and_name_missing(self):
+        bead = Bead()
+        rep = repr(bead)
+        assert "Bead" in rep
+        assert str(id(bead)) in rep
+
+
+class TestCoarseGrainPostInit:
+    """Subclass __post_init__ template hook is honoured (parallel to Atomistic)."""
+
+    def test_post_init_called_on_subclass(self):
+        captured: dict = {}
+
+        class Sub(CoarseGrain):
+            def __post_init__(self, **props):
+                captured["props"] = props
+
+        Sub(name="lipid", model="martini3")
+        assert captured["props"] == {"name": "lipid", "model": "martini3"}
+
+
+class TestCoarseGrainReprManyTypes:
+    """__repr__ collapses to '<N types>' beyond five distinct bead types."""
+
+    def test_repr_collapses_when_more_than_five_types(self):
+        cg = CoarseGrain()
+        for t in "ABCDEFG":
+            cg.def_bead(type=t)
+        rep = repr(cg)
+        assert "7 types" in rep
+
+
+class TestCoarseGrainDeletion:
+    """del_bead / del_cgbond delegate to the underlying Struct."""
+
+    def test_del_bead_removes_bead(self):
+        cg = CoarseGrain()
+        a = cg.def_bead(type="A")
+        b = cg.def_bead(type="B")
+        cg.def_cgbond(a, b)
+        cg.del_bead(a)
+        assert a not in list(cg.beads)
+        # incident bond is removed transitively
+        assert len(cg.cgbonds) == 0
+
+    def test_del_cgbond_removes_only_bond(self):
+        cg = CoarseGrain()
+        a = cg.def_bead(type="A")
+        b = cg.def_bead(type="B")
+        bond = cg.def_cgbond(a, b)
+        cg.del_cgbond(bond)
+        assert len(cg.cgbonds) == 0
+        assert len(cg.beads) == 2
+
+
+class TestCoarseGrainBatchFactory:
+    """def_cgbonds accepts both 2-tuple and 3-tuple specs."""
+
+    def test_def_cgbonds_two_tuple_no_attrs(self):
+        cg = CoarseGrain()
+        a, b, c = (cg.def_bead(type=t) for t in "ABC")
+        bonds = cg.def_cgbonds([(a, b), (b, c)])
+        assert len(bonds) == 2
+        assert all(bond.data == {} for bond in bonds)
+
+    def test_def_cgbonds_three_tuple_with_attrs(self):
+        cg = CoarseGrain()
+        a, b = cg.def_bead(type="A"), cg.def_bead(type="B")
+        bonds = cg.def_cgbonds([(a, b, {"k": 100.0})])
+        assert bonds[0].get("k") == 100.0
+
+
+class TestCoarseGrainEditing:
+    """rename_type and set_property update both beads and links."""
+
+    def test_rename_type_updates_matching_beads(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="P4")
+        cg.def_bead(type="P4")
+        cg.def_bead(type="C1")
+        n = cg.rename_type("P4", "Q4")
+        assert n == 2
+        types = sorted(b["type"] for b in cg.beads)
+        assert types == ["C1", "Q4", "Q4"]
+
+    def test_rename_type_on_links(self):
+        cg = CoarseGrain()
+        a, b = cg.def_bead(type="A"), cg.def_bead(type="B")
+        cg.def_cgbond(a, b, type="elastic")
+        n = cg.rename_type("elastic", "harmonic", kind=CGBond)
+        assert n == 1
+        assert list(cg.cgbonds)[0]["type"] == "harmonic"
+
+    def test_set_property_callable_selector(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="A", x=1.0)
+        cg.def_bead(type="A", x=-1.0)
+        n = cg.set_property(lambda b: b["x"] > 0, "region", "right")
+        assert n == 1
+        assert next(b for b in cg.beads if b["x"] > 0)["region"] == "right"
+
+    def test_set_property_rejects_non_callable(self):
+        cg = CoarseGrain()
+        with pytest.raises(TypeError):
+            cg.set_property("string-selector", "k", 1)
+
+
+class TestCoarseGrainSelectErrors:
+    """select rejects non-callable predicates."""
+
+    def test_select_rejects_non_callable(self):
+        cg = CoarseGrain()
+        with pytest.raises(TypeError):
+            cg.select("smarts-string")
+
+
+class TestCoarseGrainSpatialChaining:
+    """rotate / align return self for chaining (parallel to Atomistic)."""
+
+    def test_rotate_returns_self(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="A", x=1.0, y=0.0, z=0.0)
+        result = cg.rotate(axis=[0, 0, 1], angle=np.pi / 2)
+        assert result is cg
+
+    def test_scale_returns_self(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="A", x=1.0, y=0.0, z=0.0)
+        result = cg.scale(2.0)
+        assert result is cg
+
+    def test_align_returns_self(self):
+        cg = CoarseGrain()
+        a = cg.def_bead(type="A", x=0.0, y=0.0, z=0.0)
+        b = cg.def_bead(type="B", x=1.0, y=0.0, z=0.0)
+        result = cg.align(a, b, a_dir=[1, 0, 0], b_dir=[0, 1, 0])
+        assert result is cg
+
+
+class TestCoarseGrainToFrame:
+    """to_frame mirrors Atomistic.to_frame."""
+
+    def test_to_frame_produces_beads_block(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="P4", x=0.0, y=0.0, z=0.0, charge=-1.0)
+        cg.def_bead(type="C1", x=4.7, y=0.0, z=0.0, charge=0.0)
+
+        frame = cg.to_frame()
+        beads = frame["beads"]
+        assert len(beads["type"]) == 2
+        assert list(beads["type"]) == ["P4", "C1"]
+        assert beads["x"][0] == 0.0
+        assert beads["x"][1] == 4.7
+
+    def test_to_frame_produces_cgbonds_block_with_indices(self):
+        cg = CoarseGrain()
+        a = cg.def_bead(type="A", x=0.0, y=0.0, z=0.0)
+        b = cg.def_bead(type="B", x=1.0, y=0.0, z=0.0)
+        c = cg.def_bead(type="C", x=2.0, y=0.0, z=0.0)
+        cg.def_cgbond(a, b, k=120.0)
+        cg.def_cgbond(b, c, k=80.0)
+
+        frame = cg.to_frame()
+        cgbonds = frame["cgbonds"]
+        assert list(cgbonds["ibead"]) == [0, 1]
+        assert list(cgbonds["jbead"]) == [1, 2]
+        assert list(cgbonds["k"]) == [120.0, 80.0]
+
+    def test_to_frame_omits_cgbonds_block_when_empty(self):
+        cg = CoarseGrain()
+        cg.def_bead(type="A")
+        frame = cg.to_frame()
+        with pytest.raises(KeyError):
+            frame["cgbonds"]
+
+    def test_to_frame_field_whitelist(self):
+        cg = CoarseGrain()
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C")
+        cg.def_bead(type="P4", x=1.0, y=2.0, z=3.0, atoms=(a,))
+
+        frame = cg.to_frame(bead_fields=["x", "y", "z", "type"])
+        cols = set(frame["beads"].keys())
+        assert cols == {"x", "y", "z", "type"}
+        # atoms key was excluded
+        assert "atoms" not in cols
+
+    def test_to_frame_with_atoms_key_default_includes_object_column(self):
+        cg = CoarseGrain()
+        ato = Atomistic()
+        a = ato.def_atom(symbol="C")
+        b = ato.def_atom(symbol="H")
+        cg.def_bead(type="P4", atoms=(a, b))
+
+        frame = cg.to_frame()
+        # atoms key included as object array
+        assert "atoms" in frame["beads"].keys()
+
+    def test_to_frame_raises_on_orphan_bond_endpoint(self):
+        cg = CoarseGrain()
+        a = cg.def_bead(type="A")
+        b = cg.def_bead(type="B")
+        bond = CGBond(a, b)
+        # register a bond whose endpoints aren't in this cg
+        cg2 = CoarseGrain()
+        cg2.add_cgbond(bond)
+        cg2.def_bead(type="X")  # unrelated bead
+
+        with pytest.raises(ValueError, match="not registered"):
+            cg2.to_frame()
 
 
 if __name__ == "__main__":

--- a/tests/test_embed/test_pipeline.py
+++ b/tests/test_embed/test_pipeline.py
@@ -1,0 +1,119 @@
+"""Integration tests for :mod:`molpy.embed`.
+
+The molpy embed module is a Python wrapper around the molrs Rust ``embed``
+pipeline (built and shipped as the ``molrs`` binary extension). These tests
+exercise the wrapper end-to-end on simple skeletons.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+molrs = pytest.importorskip("molrs")
+
+from molpy import Atomistic
+from molpy.embed import EmbedReport, generate_3d
+
+
+def _bond(mol: Atomistic, a, b, order: float):
+    return mol.def_bond(a, b, order=order)
+
+
+def _coords_of(mol: Atomistic) -> np.ndarray:
+    return np.array(
+        [
+            [
+                float(a.get("x", math.nan)),
+                float(a.get("y", math.nan)),
+                float(a.get("z", math.nan)),
+            ]
+            for a in mol.atoms
+        ]
+    )
+
+
+def _all_have_coords(mol: Atomistic) -> bool:
+    return bool(np.all(np.isfinite(_coords_of(mol))))
+
+
+def _min_distance(coords: np.ndarray) -> float:
+    if len(coords) < 2:
+        return math.inf
+    dists = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=2)
+    np.fill_diagonal(dists, np.inf)
+    return float(dists.min())
+
+
+def _ethanol_skeleton() -> Atomistic:
+    mol = Atomistic()
+    c1 = mol.def_atom(element="C")
+    c2 = mol.def_atom(element="C")
+    o = mol.def_atom(element="O")
+    _bond(mol, c1, c2, 1.0)
+    _bond(mol, c2, o, 1.0)
+    return mol
+
+
+def _butane_skeleton() -> Atomistic:
+    mol = Atomistic()
+    a = mol.def_atom(element="C")
+    b = mol.def_atom(element="C")
+    c = mol.def_atom(element="C")
+    d = mol.def_atom(element="C")
+    _bond(mol, a, b, 1.0)
+    _bond(mol, b, c, 1.0)
+    _bond(mol, c, d, 1.0)
+    return mol
+
+
+def test_generate_3d_ethanol_assigns_coordinates():
+    mol = _ethanol_skeleton()
+    out, report = generate_3d(mol, rng_seed=42, add_hydrogens=True)
+
+    assert len(list(out.atoms)) > len(list(mol.atoms))
+    assert _all_have_coords(out)
+    assert isinstance(report, EmbedReport)
+    assert report.final_energy is not None and math.isfinite(report.final_energy)
+    stage_names = {s.stage for s in report.stages}
+    assert "build_initial" in stage_names
+    assert "final_optimize" in stage_names
+    assert _min_distance(_coords_of(out)) > 0.35
+
+
+def test_generate_3d_seed_reproducible():
+    mol = _butane_skeleton()
+    g1, _ = generate_3d(mol, add_hydrogens=False, rng_seed=7)
+    g2, _ = generate_3d(mol, add_hydrogens=False, rng_seed=7)
+
+    c1 = _coords_of(g1)
+    c2 = _coords_of(g2)
+    assert c1.shape == c2.shape
+    np.testing.assert_allclose(c1, c2, atol=1e-12)
+
+
+def test_generate_3d_speed_presets_validate():
+    mol = _ethanol_skeleton()
+    for speed in ("fast", "medium", "better"):
+        out, report = generate_3d(mol, speed=speed, rng_seed=3, add_hydrogens=False)
+        assert _all_have_coords(out)
+        assert report.stages, f"no stages reported for speed={speed}"
+
+
+def test_generate_3d_empty_molecule_returns_error():
+    mol = Atomistic()
+    with pytest.raises(ValueError, match="empty"):
+        generate_3d(mol)
+
+
+def test_generate_3d_preserves_template_attributes():
+    mol = Atomistic()
+    a = mol.def_atom(element="C", custom_label="alpha")
+    b = mol.def_atom(element="O", custom_label="beta")
+    _bond(mol, a, b, 1.0)
+    out, _ = generate_3d(mol, add_hydrogens=False, rng_seed=5)
+    out_atoms = list(out.atoms)
+    assert out_atoms[0].get("custom_label") == "alpha"
+    assert out_atoms[1].get("custom_label") == "beta"

--- a/tests/test_io/test_data/test_lammps_data.py
+++ b/tests/test_io/test_data/test_lammps_data.py
@@ -98,19 +98,90 @@ class TestLammpsDataReader:
         np.testing.assert_array_almost_equal(box_lengths, [10.0, 10.0, 10.0])
 
     def test_triclinic_file(self, test_files):
-        """Test reading triclinic-1.lmp - file with triclinic box."""
+        """triclinic-1.lmp — triclinic header with all-zero tilt factors
+        must produce an orthogonal-equivalent box."""
 
         reader = LammpsDataReader(test_files["triclinic_1"], atom_style="atomic")
         frame = reader.read()
 
-        # Should handle triclinic box
         assert frame.box is not None
-        box_lengths = frame.box.lengths
-        np.testing.assert_array_almost_equal(box_lengths, [34.0, 34.0, 34.0])
+        np.testing.assert_array_almost_equal(frame.box.lengths, [34.0, 34.0, 34.0])
+        np.testing.assert_array_almost_equal(frame.box.tilts, [0.0, 0.0, 0.0])
 
-        # Should have no atoms
         if "atoms" in frame:
             assert frame["atoms"].nrows == 0
+
+    def test_triclinic_2_file(self, test_files):
+        """triclinic-2.lmp — non-zero tilt factors (5 -8 3 xy xz yz) must
+        be captured in the box."""
+
+        reader = LammpsDataReader(test_files["triclinic_2"], atom_style="atomic")
+        frame = reader.read()
+
+        assert frame.box is not None
+        assert frame.box.style.name == "TRICLINIC"
+        np.testing.assert_array_almost_equal(frame.box.tilts, [5.0, -8.0, 3.0])
+        # Edge-vector norms reflect the tilt: |a|=lx, |b|=sqrt(xy^2+ly^2),
+        # |c|=sqrt(xz^2+yz^2+lz^2).
+        np.testing.assert_array_almost_equal(
+            frame.box.lengths,
+            [34.0, np.sqrt(5.0**2 + 34.0**2), np.sqrt(8.0**2 + 3.0**2 + 34.0**2)],
+        )
+
+    def test_solvated_file(self, test_files):
+        """solvated.lmp — large solvated system with full force field;
+        all header counts must be honored end-to-end."""
+
+        reader = LammpsDataReader(test_files["solvated"], atom_style="full")
+        frame = reader.read()
+
+        assert frame.box is not None
+        np.testing.assert_array_almost_equal(
+            frame.box.lengths,
+            [33.920998 - (-0.103), 33.957998 - (-0.066), 162.150494 - (-0.885501)],
+        )
+        np.testing.assert_array_almost_equal(
+            frame.box.origin, [-0.103, -0.066, -0.885501]
+        )
+
+        assert frame["atoms"].nrows == 7772
+        assert frame["bonds"].nrows == 6248
+        assert frame["angles"].nrows == 8100
+        assert frame["dihedrals"].nrows == 10720
+        assert frame["impropers"].nrows == 1376
+
+        assert frame.metadata["counts"]["atom_types"] == 11
+        assert frame.metadata["counts"]["bond_types"] == 8
+
+    def test_data_body_file(self, test_files):
+        """data.body — atom_style='body' must read 'bodyflag' and per-atom
+        'mass' columns, and a trailing 'Bodies' section must not leak into
+        the atoms block."""
+
+        reader = LammpsDataReader(test_files["data_body"], atom_style="body")
+        frame = reader.read()
+
+        assert frame.box is not None
+        np.testing.assert_array_almost_equal(
+            frame.box.lengths,
+            [
+                15.532224567 - (-15.532224567),
+                15.532224567 - (-15.532224567),
+                0.5 - (-0.5),
+            ],
+        )
+
+        atoms = frame["atoms"]
+        assert atoms.nrows == 100  # header says 100 atoms; not 277
+        for col in ("id", "type", "bodyflag", "mass", "x", "y", "z"):
+            assert col in atoms, f"body atom_style must expose {col!r}"
+        # First atom in the file: 1 1 1 6 -15.5322 -15.5322 0 1 2 0
+        assert int(atoms["bodyflag"][0]) == 1
+        assert float(atoms["mass"][0]) == 6.0
+        np.testing.assert_array_almost_equal(
+            [atoms["x"][0], atoms["y"][0], atoms["z"][0]],
+            [-15.5322, -15.5322, 0.0],
+        )
 
     def test_labelmap_file(self, test_files):
         """Test reading labelmap.lmp - file with type labels and connectivity."""
@@ -341,17 +412,60 @@ class TestErrorHandling:
             reader.read()
 
     def test_empty_file(self, tmp_path):
-        """Test reading empty file."""
+        """Empty files have no box and must raise rather than silently
+        falling back to a default box."""
         tmp_file = tmp_path / "test.data"
         with open(tmp_file, "w") as f:
             f.write("")
 
         reader = LammpsDataReader(tmp_file)
+        with pytest.raises(ValueError, match="missing box bounds"):
+            reader.read()
+
+    def test_missing_box_axis_raises(self, tmp_path):
+        """A header missing one axis must raise — no silent default."""
+        content = (
+            "# missing z\n"
+            "1 atoms\n"
+            "1 atom types\n"
+            "\n"
+            "0.0 10.0 xlo xhi\n"
+            "0.0 10.0 ylo yhi\n"
+            "\n"
+            "Atoms\n"
+            "\n"
+            "1 1 0.0 0.0 0.0\n"
+        )
+        tmp_file = tmp_path / "missing_z.data"
+        tmp_file.write_text(content)
+
+        reader = LammpsDataReader(tmp_file, atom_style="atomic")
+        with pytest.raises(ValueError, match=r"missing box bounds for axis \['z'\]"):
+            reader.read()
+
+    def test_float_box_bounds_parsed(self, tmp_path):
+        """Regression: float-valued box bounds must parse, not fall back to 10x10x10."""
+        content = (
+            "# float bounds\n"
+            "1 atoms\n"
+            "1 atom types\n"
+            "\n"
+            "0.0 25.0 xlo xhi\n"
+            "0.0 30.0 ylo yhi\n"
+            "0.0 35.0 zlo zhi\n"
+            "\n"
+            "Atoms\n"
+            "\n"
+            "1 1 0.0 0.0 0.0\n"
+        )
+        tmp_file = tmp_path / "float_box.data"
+        tmp_file.write_text(content)
+
+        reader = LammpsDataReader(tmp_file, atom_style="atomic")
         frame = reader.read()
 
-        # Should handle empty file gracefully
-        assert frame is not None
-        assert "atoms" not in frame
+        assert frame.box is not None
+        np.testing.assert_array_almost_equal(frame.box.lengths, [25.0, 30.0, 35.0])
 
     def test_malformed_header(self, tmp_path):
         """Test reading file with malformed header."""

--- a/tests/test_io/test_data/test_lammps_data_parity.py
+++ b/tests/test_io/test_data/test_lammps_data_parity.py
@@ -1,0 +1,234 @@
+"""Parametrized parity tests between molpy.io and molrs.io.
+
+Each scenario corresponds to one file in ``tests-data/lammps-data/`` —
+the filename is the test point. The same test body runs against both
+``molpy.io.read_lammps_data`` and ``molrs.io.read_lammps_data`` to prove
+the molrs reader is a drop-in replacement under duck typing: same
+attribute names (``frame.box.lengths``, ``frame.box.tilts``,
+``block[key]``), same row counts, same coordinates.
+
+Per-reader differences (canonical vs format-specific column naming, the
+``charge``/``mol_id`` translation) are bridged by small accessor helpers
+so the assertion bodies stay reader-agnostic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import molpy.io as molpy_io
+import molrs.io as molrs_io
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Reader parametrization
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _molpy_read(path: Path, atom_style: str):
+    return molpy_io.read_lammps_data(path, atom_style=atom_style)
+
+
+def _molrs_read(path: Path, atom_style: str):
+    return molrs_io.read_lammps_data(path, atom_style=atom_style)
+
+
+READERS = [
+    pytest.param(_molpy_read, id="molpy"),
+    pytest.param(_molrs_read, id="molrs"),
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Test-data fixture (re-declared locally so this file is self-contained)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def test_files(TEST_DATA_DIR) -> dict[str, Path]:
+    d = TEST_DATA_DIR / "lammps-data"
+    return {
+        "molid": d / "molid.lmp",
+        "whitespaces": d / "whitespaces.lmp",
+        "triclinic_1": d / "triclinic-1.lmp",
+        "triclinic_2": d / "triclinic-2.lmp",
+        "labelmap": d / "labelmap.lmp",
+        "solvated": d / "solvated.lmp",
+        "data_body": d / "data.body",
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Duck-typing helpers
+#
+# The two readers produce different concrete column names for the same
+# physical quantity (molpy canonicalizes to ``mol_id``/``charge``; molrs
+# keeps the LAMMPS-shaped ``molecule_id``/``charge``). These helpers pick
+# whichever is present so the assertion bodies stay reader-agnostic.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _col(block, *candidates: str) -> np.ndarray:
+    for name in candidates:
+        if name in block:
+            return np.asarray(block[name])
+    raise AssertionError(
+        f"none of {candidates!r} present in block; have {list(block.keys())!r}"
+    )
+
+
+def _mol_id(block) -> np.ndarray:
+    return _col(block, "mol_id", "molecule_id")
+
+
+def _charge(block) -> np.ndarray:
+    return _col(block, "charge", "q")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# One test per file. Filename == test point.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_molid_file(read, test_files):
+    """molid.lmp — atom_style full with mol IDs, integer box bounds 0-20."""
+    frame = read(test_files["molid"], "full")
+    atoms = frame["atoms"]
+
+    assert atoms.nrows == 12
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths), [20.0, 20.0, 20.0]
+    )
+    np.testing.assert_array_almost_equal(np.asarray(frame.box.origin), [0.0, 0.0, 0.0])
+    np.testing.assert_array_almost_equal(np.asarray(frame.box.tilts), [0.0, 0.0, 0.0])
+
+    # Canonical/format-specific mol-id column must be present.
+    mol_ids = _mol_id(atoms)
+    assert len(mol_ids) == 12
+    assert set(np.unique(mol_ids).tolist()) <= {0, 1, 2, 3}
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_whitespaces_file(read, test_files):
+    """whitespaces.lmp — extra whitespace tolerance + float box bounds."""
+    frame = read(test_files["whitespaces"], "full")
+    atoms = frame["atoms"]
+
+    assert atoms.nrows == 1
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths), [10.0, 10.0, 10.0]
+    )
+    np.testing.assert_array_almost_equal(
+        [
+            float(np.asarray(atoms["x"])[0]),
+            float(np.asarray(atoms["y"])[0]),
+            float(np.asarray(atoms["z"])[0]),
+        ],
+        [5.0, 5.0, 5.0],
+    )
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_triclinic_1_file(read, test_files):
+    """triclinic-1.lmp — triclinic header with all-zero tilts."""
+    frame = read(test_files["triclinic_1"], "atomic")
+
+    assert frame.box is not None
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths), [34.0, 34.0, 34.0]
+    )
+    np.testing.assert_array_almost_equal(np.asarray(frame.box.tilts), [0.0, 0.0, 0.0])
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_triclinic_2_file(read, test_files):
+    """triclinic-2.lmp — non-zero tilt factors (5, -8, 3 = xy, xz, yz)."""
+    frame = read(test_files["triclinic_2"], "atomic")
+
+    assert frame.box is not None
+    np.testing.assert_array_almost_equal(np.asarray(frame.box.tilts), [5.0, -8.0, 3.0])
+    # Edge-vector norms reflect the tilt: |a|=lx, |b|=sqrt(xy^2+ly^2),
+    # |c|=sqrt(xz^2+yz^2+lz^2).
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths),
+        [
+            34.0,
+            np.sqrt(5.0**2 + 34.0**2),
+            np.sqrt(8.0**2 + 3.0**2 + 34.0**2),
+        ],
+    )
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_labelmap_file(read, test_files):
+    """labelmap.lmp — atom/bond/angle/dihedral type labels + connectivity."""
+    frame = read(test_files["labelmap"], "full")
+
+    assert frame["atoms"].nrows == 16
+    assert frame["bonds"].nrows == 14
+    assert frame["angles"].nrows == 25
+    assert frame["dihedrals"].nrows == 27
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_solvated_file(read, test_files):
+    """solvated.lmp — large system with bonds/angles/dihedrals/impropers."""
+    frame = read(test_files["solvated"], "full")
+
+    assert frame["atoms"].nrows == 7772
+    assert frame["bonds"].nrows == 6248
+    assert frame["angles"].nrows == 8100
+    assert frame["dihedrals"].nrows == 10720
+    assert frame["impropers"].nrows == 1376
+
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths),
+        [
+            33.920998 - (-0.103),
+            33.957998 - (-0.066),
+            162.150494 - (-0.885501),
+        ],
+    )
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.origin), [-0.103, -0.066, -0.885501]
+    )
+
+    # Mol IDs and charges must be present (under either column name).
+    assert len(_mol_id(frame["atoms"])) == 7772
+    assert len(_charge(frame["atoms"])) == 7772
+
+
+@pytest.mark.parametrize("read", READERS)
+def test_data_body_file(read, test_files):
+    """data.body — atom_style='body' must expose per-atom bodyflag + mass."""
+    frame = read(test_files["data_body"], "body")
+    atoms = frame["atoms"]
+
+    assert atoms.nrows == 100
+    np.testing.assert_array_almost_equal(
+        np.asarray(frame.box.lengths),
+        [
+            15.532224567 - (-15.532224567),
+            15.532224567 - (-15.532224567),
+            0.5 - (-0.5),
+        ],
+    )
+
+    for col in ("id", "type", "bodyflag", "mass", "x", "y", "z"):
+        assert col in atoms, f"body atom_style must expose {col!r}"
+
+    # First atom: 1 1 1 6 -15.5322 -15.5322 0 ...
+    assert int(np.asarray(atoms["bodyflag"])[0]) == 1
+    assert float(np.asarray(atoms["mass"])[0]) == 6.0
+    np.testing.assert_array_almost_equal(
+        [
+            float(np.asarray(atoms["x"])[0]),
+            float(np.asarray(atoms["y"])[0]),
+            float(np.asarray(atoms["z"])[0]),
+        ],
+        [-15.5322, -15.5322, 0.0],
+    )

--- a/tests/test_io/test_log/test_lammps_log.py
+++ b/tests/test_io/test_log/test_lammps_log.py
@@ -1,10 +1,17 @@
-"""Tests for ``molpy.io.LAMMPSLog`` thermo extraction."""
+"""Tests for ``molpy.io.LAMMPSLog`` parsing."""
 
+import json
 from pathlib import Path
 
 import pytest
 
-from molpy.io import LAMMPSLog
+from molpy.io import LAMMPSLog, read_LAMMPS_log
+
+
+def _write_log(tmp_path: Path, text: str) -> Path:
+    log_file = tmp_path / "log.lammps"
+    log_file.write_text(text.strip() + "\n")
+    return log_file
 
 
 def test_lammps_log_reads_default_thermo(TEST_DATA_DIR: Path) -> None:
@@ -77,3 +84,91 @@ def test_lammps_log_parses_two_stages(tmp_path: Path) -> None:
     assert log["n_stages"] == 2
     assert log["stages"][0]["Step"][0] == 0
     assert log["stages"][1]["Step"][0] == 20
+
+
+def test_read_LAMMPS_log_returns_nested_run_structure(tmp_path: Path) -> None:
+    """New API follows LAMMPS run output sections."""
+    log_file = _write_log(
+        tmp_path,
+        """
+LAMMPS (1 Jan 2026)
+using 1 OpenMP thread(s) per MPI task
+Per MPI rank memory allocation (min/avg/max) = 4.5 | 4.75 | 5.0 Mbytes
+Step Temp PotEng E_pair
+0 300.0 -1000.0 -900.0
+10 305.0 -1010.0 -910.0
+Loop time of 0.2 on 2 procs for 10 steps with 100 atoms
+Performance: 432.0 ns/day, 0.056 hours/ns, 50.0 timesteps/s, 5.0 katom-step/s
+98.5% CPU use with 2 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.010 | 0.011 | 0.012 | 0.0 | 55.0
+Neigh   | 0.002 | 0.003 | 0.004 | 0.0 | 15.0
+
+Thread timings breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.005 | 0.006 | 0.007 | 0.0 | 30.0
+
+Nlocal:    50 ave 55 max 45 min
+Histogram: 1 0 0 0 0 0 0 0 0 1
+Nghost:    10 ave 12 max 8 min
+Histogram: 0 1 0 0 0 0 0 0 1 0
+Neighs:    150 ave 160 max 140 min
+Histogram: 0 0 1 0 0 0 0 1 0 0
+Total # of neighbors = 300
+Ave neighs/atom = 3.0
+Ave special neighs/atom = 2.0
+Neighbor list builds = 1
+Dangerous builds = 0
+WARNING: test warning
+Total wall time: 0:00:01
+""",
+    )
+
+    log = read_LAMMPS_log(log_file)
+
+    assert log.version == "LAMMPS (1 Jan 2026)"
+    assert log.total_wall_time == "0:00:01"
+    assert len(log.runs) == 1
+
+    run = log.runs[0]
+    assert run.memory.average == 4.75
+    assert run.thermo.columns == ("Step", "Temp", "PotEng", "E_pair")
+    assert run.thermo.data["Step"].tolist() == [0.0, 10.0]
+    assert run.loop_time.procs == 2
+    assert run.loop_time.steps == 10
+    assert run.loop_time.atoms == 100
+    assert run.performance.atom_steps_units == "katom-step/s"
+    assert run.CPU_use.MPI_tasks == 2
+    assert run.CPU_use.OMP_threads == 1
+    assert run.MPI_task_timing.rows[0].section == "Pair"
+    assert run.thread_timing.rows[0].percent_total == 30.0
+    assert run.load_balance[0].name == "Nlocal"
+    assert run.load_balance[0].histogram == (1, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+    assert run.neighbor_statistics.total_neighbors == 300
+    assert run.neighbor_statistics.dangerous_builds == 0
+    assert run.warnings[0].message == "test warning"
+    assert "Step Temp PotEng E_pair" in run.raw_text
+
+
+def test_read_LAMMPS_log_to_dict_is_json_friendly(tmp_path: Path) -> None:
+    """Nested dataclasses serialize without NumPy objects."""
+    log_file = _write_log(
+        tmp_path,
+        """
+LAMMPS (1 Jan 2026)
+Per MPI rank memory allocation (min/avg/max) = 1 | 1 | 1 Mbytes
+Step Temp
+0 300
+Loop time of 0.1 on 1 procs for 0 steps with 1 atoms
+""",
+    )
+    payload = read_LAMMPS_log(log_file).to_dict()
+
+    json.dumps(payload)
+    assert payload["runs"][0]["thermo"]["columns"] == ["Step", "Temp"]
+    assert payload["runs"][0]["CPU_use"] is None
+    assert payload["stages"][0]["rows"] == [[0.0, 300.0]]


### PR DESCRIPTION
## Summary
- **molrs backend (required)** — `Box(molrs.Box)`, NeighborList + RDF compute ops forwarding to molrs primitives. `molcrafts-molrs ≥0.0.8` is now a hard runtime dependency (the optional-backend framing is gone).
- **3D embed pipeline** — new `molpy.embed.generate_3d` wraps molrs's Rust embed pipeline; bridge in `core/_molrs.py`. RDKit-based embed/adapter remain available.
- **LAMMPS log reader** — robust multi-stage parser via `io/log/lammps.py`.
- **CoarseGrain refactor** — `core/cg.py` simplified to mirror `Atomistic`.

## Test plan
- [x] `pytest tests/ -m "not external"` — 1621 passed, 81 skipped locally
- [x] Pre-commit hooks (ruff format/lint, ty type check) clean
- [ ] CI matrix green
- [ ] Verify molrs ≥0.0.8 wheels available on all CI Python versions