### PR TITLE
chore(release): molpy 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "python-igraph>=1.0.0",
     "lark>=1.3.1",
     "pint>=0.24",
-    "molcrafts-molrs==0.1.2",
+    "molcrafts-molrs==0.1.3",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Cuts molpy **0.4.1**.

## ⚠️ Release ordering (dependency)
Requires **`molcrafts-molrs==0.1.3`** — the ff-perinstance release (MolCrafts/molrs#31).
**Merge + publish molrs 0.1.3 to PyPI first.** Until then this PR's CI will be red (the pinned dep can't be resolved from PyPI). After molrs 0.1.3 is on PyPI, CI goes green → merge → tag `v0.4.1` → `release.yml` publishes to PyPI.

## 0.4.1 content
- Removed `molpy.legacy` module.
- AMBER prmtop connectivity indices emitted as uint32.
- Bumped molrs pin `==0.1.2` → `==0.1.3` (this branch's release prep).