### PR TITLE
ci: drop Windows from the test matrix (tests-data con/ reserved name)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # No windows-latest: the tests-data repo (a fork of chemfiles/tests-data)
+        # contains a `con/` directory, and `con` is a reserved device name on
+        # Windows — git cannot check out the working tree there at all, so the
+        # data-dependent tests could never run. We keep tests-data a clean mirror
+        # of upstream (so fork syncs stay conflict-free) and simply don't run CI
+        # on Windows. The conftest fixture still skips data tests gracefully for
+        # any consumer that pulls tests-data into an environment where it isn't
+        # fully available (local Windows, offline, etc.).
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.12', '3.13']
 
     steps:
@@ -63,24 +71,13 @@ jobs:
 
       # Clone tests-data once, serially, before the parallel (-n auto) test run.
       # Under xdist the session fixture runs per-worker, so a git op there would
-      # mutate the shared checkout while other workers read it (Windows-fatal).
-      # Pre-fetching here means every worker sees a stable tree.
-      #
-      # tests-data has a `con/` directory (EON-format fixtures); `con` is a
-      # reserved device name on Windows, so its working tree cannot be checked
-      # out there. On Windows we clone metadata only (--no-checkout) so the step
-      # succeeds deterministically; the conftest fixture then skips the
-      # data-dependent tests (none of which molpy runs on Windows anyway). On
-      # Linux/macOS the full clone must succeed — a failure here fails the job.
+      # mutate the shared checkout while other workers read it. Pre-fetching here
+      # means every worker sees a complete, stable tree.
       - name: Fetch test data
         shell: bash
         run: |
-          url=https://github.com/molcrafts/tests-data.git
-          if [ -d tests/tests-data/.git ]; then exit 0; fi
-          if [ "${RUNNER_OS:-}" = "Windows" ]; then
-            git clone --depth 1 --no-checkout "$url" tests/tests-data
-          else
-            git clone --depth 1 "$url" tests/tests-data
+          if [ ! -d tests/tests-data/.git ]; then
+            git clone --depth 1 https://github.com/molcrafts/tests-data.git tests/tests-data
           fi
 
       - name: Run tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,18 +53,19 @@ _SENTINEL = _DEFAULT_DIR / "README.md"
 def _ensure_test_data() -> Path:
     """Clone tests-data if absent; skip data tests when the checkout is incomplete.
 
-    On Windows the repo cannot be fully checked out: it contains a ``con/``
-    directory (EON-format fixtures) and ``con`` is a reserved device name, so git
-    aborts the working-tree checkout. Rather than fail, detect the incomplete tree
-    via a sentinel (``README.md``, always present in a full checkout) and skip the
-    data-dependent tests — matching the pre-existing behavior where the Windows
-    clone failed and these tests were skipped.
+    Skips (rather than fails) the data-dependent tests whenever tests-data is not
+    fully available — offline runs, or a platform that cannot check out the whole
+    tree. The tests-data repo (a fork of chemfiles/tests-data) contains a ``con/``
+    directory and ``con`` is a reserved device name on Windows, so git aborts the
+    working-tree checkout there; molpy's CI does not run on Windows for this
+    reason, but the graceful skip keeps a local Windows checkout usable. An
+    incomplete tree is detected via a sentinel (``README.md``, always present in a
+    full checkout).
 
     Deliberately does NOT ``git pull`` a present checkout: under ``-n auto`` the
     session fixture runs once per worker, so pulling would mutate the shared
-    working tree while other workers read from it — which surfaced as spurious
-    "path not found" file reads on Windows. CI clones fresh each run (in a serial
-    pre-test step); to refresh a local copy, delete tests/tests-data.
+    working tree while other workers read from it. CI clones fresh each run (in a
+    serial pre-test step); to refresh a local copy, delete tests/tests-data.
     """
     if not (_DEFAULT_DIR / ".git").exists():
         _DEFAULT_DIR.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Why

`tests-data` is a **fork of chemfiles/tests-data** and carries a `con/` directory (EON-format fixtures). `con` is a **reserved device name on Windows**, so `git` cannot check out the working tree there at all — the data-dependent tests could never run on Windows.

Renaming `con/` in the fork is **not** an option: the fork must stay a clean mirror of upstream so periodic syncs from `chemfiles/tests-data` stay conflict-free (a rename would diverge and get clobbered on the next sync).

## What

- **Drop `windows-latest`** from the test matrix (`os: [ubuntu-latest, macos-latest]`) instead of carrying a Windows-only checkout workaround. Windows never ran the data tests anyway (the old fixture silently skipped them on the failed clone).
- **Revert the CI "Fetch test data" step to a plain clone** — removes the `--no-checkout` / `RUNNER_OS` branching added in #37.
- **Keep the conftest graceful skip** (`README.md` sentinel): any consumer that pulls tests-data into an environment where it isn't fully available (local Windows, offline) skips the data tests instead of failing.

Neither molpy nor molrs reads `con/` data, and no EON reader exists — the fixtures are orphaned upstream data, so dropping Windows coverage of them costs nothing.

## Follow-up to

#37 (pytest-xdist). The xdist speedup stays; this just removes the Windows platform that can't consume tests-data.

## Test plan

- [x] ubuntu/macos CI green under `-n auto`
- [x] `ruff format --check` / `ruff check` clean on conftest
- [x] YAML validates