### PR TITLE
ci: skip the con/ dir via sparse-checkout (keep Windows CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,25 +63,23 @@ jobs:
 
       # Clone tests-data once, serially, before the parallel (-n auto) test run.
       # Under xdist the session fixture runs per-worker, so a git op there would
-      # mutate the shared checkout while other workers read it (Windows-fatal).
-      # Pre-fetching here means every worker sees a stable tree.
+      # mutate the shared checkout while other workers read it. Pre-fetching here
+      # means every worker sees a complete, stable tree.
       #
-      # tests-data has a `con/` directory (EON-format fixtures); `con` is a
-      # reserved device name on Windows, so its working tree cannot be checked
-      # out there. On Windows we clone metadata only (--no-checkout) so the step
-      # succeeds deterministically; the conftest fixture then skips the
-      # data-dependent tests (none of which molpy runs on Windows anyway). On
-      # Linux/macOS the full clone must succeed — a failure here fails the job.
+      # Exclude the `con/` directory at checkout via sparse-checkout: tests-data
+      # (a fork of chemfiles/tests-data) ships EON fixtures under `con/`, but `con`
+      # is a reserved device name on Windows and git cannot materialize it there.
+      # We read no con/ data anywhere, so dropping it on every platform keeps the
+      # tree identical across OSes and lets the full suite (Windows included)
+      # check out and run.
       - name: Fetch test data
         shell: bash
         run: |
-          url=https://github.com/molcrafts/tests-data.git
-          if [ -d tests/tests-data/.git ]; then exit 0; fi
-          if [ "${RUNNER_OS:-}" = "Windows" ]; then
-            git clone --depth 1 --no-checkout "$url" tests/tests-data
-          else
-            git clone --depth 1 "$url" tests/tests-data
-          fi
+          dir=tests/tests-data
+          if [ -d "$dir/.git" ]; then exit 0; fi
+          git clone --depth 1 --no-checkout https://github.com/molcrafts/tests-data.git "$dir"
+          git -C "$dir" sparse-checkout set --no-cone '/*' '!/con/'
+          git -C "$dir" checkout
 
       - name: Run tests
         run: pytest tests/ -m "not external" -n auto --cov=src/molpy --cov-report=xml --cov-report=term

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,20 +66,17 @@ jobs:
       # mutate the shared checkout while other workers read it. Pre-fetching here
       # means every worker sees a complete, stable tree.
       #
-      # Exclude the `con/` directory at checkout via sparse-checkout: tests-data
-      # (a fork of chemfiles/tests-data) ships EON fixtures under `con/`, but `con`
-      # is a reserved device name on Windows and git cannot materialize it there.
-      # We read no con/ data anywhere, so dropping it on every platform keeps the
-      # tree identical across OSes and lets the full suite (Windows included)
-      # check out and run.
+      # Windows note: tests-data (a fork of chemfiles/tests-data) used to carry a
+      # `con/` directory — a reserved device name Windows cannot check out. It has
+      # been removed upstream, so a plain clone now works on every platform.
+      # (Sparse-checkout does NOT help: git rejects the reserved path during
+      # checkout before sparse rules apply. Keeping con/ out of the fork is the fix.)
       - name: Fetch test data
         shell: bash
         run: |
-          dir=tests/tests-data
-          if [ -d "$dir/.git" ]; then exit 0; fi
-          git clone --depth 1 --no-checkout https://github.com/molcrafts/tests-data.git "$dir"
-          git -C "$dir" sparse-checkout set --no-cone '/*' '!/con/'
-          git -C "$dir" checkout
+          if [ ! -d tests/tests-data/.git ]; then
+            git clone --depth 1 https://github.com/molcrafts/tests-data.git tests/tests-data
+          fi
 
       - name: Run tests
         run: pytest tests/ -m "not external" -n auto --cov=src/molpy --cov-report=xml --cov-report=term

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,26 +61,26 @@ jobs:
         # just re-run after molrs publishes.
         run: pip install -e ".[dev]"
 
-      # Clone tests-data once, serially, before the parallel (-n auto) test run.
+      # Fetch tests-data once, serially, before the parallel (-n auto) test run.
       # Under xdist the session fixture runs per-worker, so a git op there would
       # mutate the shared checkout while other workers read it. Pre-fetching here
       # means every worker sees a complete, stable tree.
       #
-      # Skip the `con/` directory at checkout, leaving tests-data itself untouched.
-      # tests-data (a fork of chemfiles/tests-data) ships EON fixtures under con/,
-      # a reserved device name Windows cannot create. Two settings are BOTH
-      # required on Windows: core.protectNTFS=false lets git process the con/ index
-      # entry without rejecting the name, and sparse-checkout keeps con/ off disk so
-      # the OS is never asked to create it. Nothing reads con/ data.
+      # Download the archive and extract everything EXCEPT `con/`, rather than
+      # git-cloning — leaving tests-data itself untouched. tests-data (a fork of
+      # chemfiles/tests-data) ships EON fixtures under con/, a reserved device name
+      # Windows cannot create; a git checkout aborts there ("cannot create
+      # directory at 'con'") and sparse-checkout can't reliably exclude it on
+      # Windows. Extracting the tarball without con/ never asks the OS to create
+      # it, so it works on every platform. Nothing reads con/ data.
       - name: Fetch test data
         shell: bash
         run: |
           dir=tests/tests-data
-          if [ -d "$dir/.git" ]; then exit 0; fi
-          git clone --depth 1 --no-checkout https://github.com/molcrafts/tests-data.git "$dir"
-          git -C "$dir" config core.protectNTFS false
-          git -C "$dir" sparse-checkout set --no-cone '/*' '!/con/'
-          git -C "$dir" checkout
+          if [ -e "$dir/README.md" ]; then exit 0; fi
+          mkdir -p "$dir"
+          curl -fsSL https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz \
+            | tar -xz -C "$dir" --strip-components=1 --exclude='*/con' --exclude='*/con/*'
 
       - name: Run tests
         run: pytest tests/ -m "not external" -n auto --cov=src/molpy --cov-report=xml --cov-report=term

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,21 @@ jobs:
       # mutate the shared checkout while other workers read it. Pre-fetching here
       # means every worker sees a complete, stable tree.
       #
-      # Windows note: tests-data (a fork of chemfiles/tests-data) used to carry a
-      # `con/` directory — a reserved device name Windows cannot check out. It has
-      # been removed upstream, so a plain clone now works on every platform.
-      # (Sparse-checkout does NOT help: git rejects the reserved path during
-      # checkout before sparse rules apply. Keeping con/ out of the fork is the fix.)
+      # Skip the `con/` directory at checkout, leaving tests-data itself untouched.
+      # tests-data (a fork of chemfiles/tests-data) ships EON fixtures under con/,
+      # a reserved device name Windows cannot create. Two settings are BOTH
+      # required on Windows: core.protectNTFS=false lets git process the con/ index
+      # entry without rejecting the name, and sparse-checkout keeps con/ off disk so
+      # the OS is never asked to create it. Nothing reads con/ data.
       - name: Fetch test data
         shell: bash
         run: |
-          if [ ! -d tests/tests-data/.git ]; then
-            git clone --depth 1 https://github.com/molcrafts/tests-data.git tests/tests-data
-          fi
+          dir=tests/tests-data
+          if [ -d "$dir/.git" ]; then exit 0; fi
+          git clone --depth 1 --no-checkout https://github.com/molcrafts/tests-data.git "$dir"
+          git -C "$dir" config core.protectNTFS false
+          git -C "$dir" sparse-checkout set --no-cone '/*' '!/con/'
+          git -C "$dir" checkout
 
       - name: Run tests
         run: pytest tests/ -m "not external" -n auto --cov=src/molpy --cov-report=xml --cov-report=term

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import contextlib
-import subprocess
+import io
+import tarfile
+import urllib.request
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
@@ -7,7 +9,9 @@ import mollog
 import pytest
 from filelock import FileLock
 
-_REPO_URL = "https://github.com/molcrafts/tests-data.git"
+_TARBALL_URL = (
+    "https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz"
+)
 _DEFAULT_DIR = Path(__file__).resolve().parent / "tests-data"
 
 
@@ -51,52 +55,42 @@ _SENTINEL = _DEFAULT_DIR / "README.md"
 
 
 def _ensure_test_data() -> Path:
-    """Clone tests-data (skipping ``con/``) if absent; skip data tests if absent.
+    """Download tests-data (minus ``con/``) if absent; skip data tests if it isn't.
 
-    tests-data (a fork of chemfiles/tests-data) ships EON fixtures under ``con/``,
-    a reserved device name Windows cannot create — a plain clone aborts there. We
-    leave tests-data untouched and skip con/ at checkout instead. Two settings are
-    BOTH required on Windows: ``core.protectNTFS=false`` lets git process the con/
-    index entry without rejecting the name, and sparse-checkout keeps con/ off disk
-    so the OS is never asked to create it (nothing reads con/ data). If tests-data
-    still isn't available (e.g. offline), skip the data-dependent tests via a
+    Fetches the archive and extracts everything except the ``con/`` directory,
+    rather than git-cloning. tests-data (a fork of chemfiles/tests-data) ships EON
+    fixtures under ``con/`` — a reserved device name Windows cannot create, so a
+    git checkout aborts there ("cannot create directory at 'con'") and
+    sparse-checkout can't reliably exclude it on Windows. Extracting the tarball
+    without con/ never asks the OS to create it, so this works on every platform
+    (nothing reads con/ data) and leaves tests-data itself untouched. If the
+    download fails (e.g. offline), skip the data-dependent tests via a
     ``README.md`` sentinel rather than failing.
 
-    Deliberately does NOT ``git pull`` a present checkout: under ``-n auto`` the
-    session fixture runs once per worker, so pulling would mutate the shared
-    working tree while other workers read from it. CI clones fresh each run (in a
-    serial pre-test step); to refresh a local copy, delete tests/tests-data.
+    An existing checkout (git clone or a previous extract) is reused as-is and
+    deliberately NOT refreshed: under ``-n auto`` the session fixture runs once
+    per worker, and a concurrent refresh would corrupt the shared tree. CI
+    fetches fresh each run (in a serial pre-test step); to refresh a local copy,
+    delete tests/tests-data.
     """
-    if not (_DEFAULT_DIR / ".git").exists():
-        _DEFAULT_DIR.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--no-checkout",
-                _REPO_URL,
-                str(_DEFAULT_DIR),
-            ],
-            cwd=_DEFAULT_DIR.parent,
-        )
-        subprocess.run(
-            ["git", "-C", str(_DEFAULT_DIR), "config", "core.protectNTFS", "false"]
-        )
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(_DEFAULT_DIR),
-                "sparse-checkout",
-                "set",
-                "--no-cone",
-                "/*",
-                "!/con/",
-            ],
-        )
-        subprocess.run(["git", "-C", str(_DEFAULT_DIR), "checkout"])
+    if not _SENTINEL.exists():
+        try:
+            with urllib.request.urlopen(_TARBALL_URL, timeout=60) as resp:
+                raw = resp.read()
+        except OSError:
+            pytest.skip("tests-data unavailable (download failed)")
+        _DEFAULT_DIR.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar:
+            members = []
+            for member in tar.getmembers():
+                # Archive paths are "tests-data-<ref>/<rel>"; drop the root
+                # component and skip the Windows-reserved con/ directory.
+                _, _, rel = member.name.partition("/")
+                if not rel or rel == "con" or rel.startswith("con/"):
+                    continue
+                member.name = rel
+                members.append(member)
+            tar.extractall(_DEFAULT_DIR, members=members, filter="data")
     if not _SENTINEL.exists():
         pytest.skip("tests-data checkout unavailable or incomplete")
     return _DEFAULT_DIR
@@ -104,15 +98,13 @@ def _ensure_test_data() -> Path:
 
 @pytest.fixture(scope="session", name="TEST_DATA_DIR")
 def find_test_data(tmp_path_factory, worker_id) -> Path:
-    """Ensure the tests-data repository is present and up-to-date.
+    """Ensure the tests-data repository is present.
 
     xdist-safe: the session fixture runs once **per worker**, so without a lock
-    all workers would `git clone`/`pull` the *same* directory concurrently and
-    corrupt each other's checkout (Windows is strict about concurrent file
-    access — this manifested as spurious "path not found" file-read failures
-    under ``-n auto``). Serialize the git operation across workers with a
-    cross-process lock on a shared path; ``git pull --ff-only`` is idempotent so
-    running it once per worker (in turn) is harmless.
+    all workers would download/extract into the *same* directory concurrently and
+    corrupt each other's tree. Serialize the fetch across workers with a
+    cross-process lock on a shared path; ``_ensure_test_data`` is a no-op once the
+    tree is present, so running it once per worker (in turn) is harmless.
     """
     if worker_id == "master":
         # Not running under xdist — no other workers to race with.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,27 +51,47 @@ _SENTINEL = _DEFAULT_DIR / "README.md"
 
 
 def _ensure_test_data() -> Path:
-    """Clone tests-data if absent; skip data tests when the checkout is incomplete.
+    """Clone tests-data (minus ``con/``) if absent; skip data tests if unavailable.
 
-    On Windows the repo cannot be fully checked out: it contains a ``con/``
-    directory (EON-format fixtures) and ``con`` is a reserved device name, so git
-    aborts the working-tree checkout. Rather than fail, detect the incomplete tree
-    via a sentinel (``README.md``, always present in a full checkout) and skip the
-    data-dependent tests — matching the pre-existing behavior where the Windows
-    clone failed and these tests were skipped.
+    The tests-data repo (a fork of chemfiles/tests-data) ships EON fixtures under
+    ``con/``, but ``con`` is a reserved device name on Windows and git cannot
+    materialize it there. We read no ``con/`` data, so the checkout excludes it via
+    sparse-checkout on every platform — keeping the tree identical across OSes and
+    checkoutable on Windows. If tests-data still isn't available (e.g. offline),
+    skip the data-dependent tests via a sentinel rather than failing.
 
     Deliberately does NOT ``git pull`` a present checkout: under ``-n auto`` the
     session fixture runs once per worker, so pulling would mutate the shared
-    working tree while other workers read from it — which surfaced as spurious
-    "path not found" file reads on Windows. CI clones fresh each run (in a serial
-    pre-test step); to refresh a local copy, delete tests/tests-data.
+    working tree while other workers read from it. CI clones fresh each run (in a
+    serial pre-test step); to refresh a local copy, delete tests/tests-data.
     """
     if not (_DEFAULT_DIR / ".git").exists():
         _DEFAULT_DIR.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            ["git", "clone", "--depth", "1", _REPO_URL, str(_DEFAULT_DIR)],
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--no-checkout",
+                _REPO_URL,
+                str(_DEFAULT_DIR),
+            ],
             cwd=_DEFAULT_DIR.parent,
         )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(_DEFAULT_DIR),
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                "!/con/",
+            ],
+        )
+        subprocess.run(["git", "-C", str(_DEFAULT_DIR), "checkout"])
     if not _SENTINEL.exists():
         pytest.skip("tests-data checkout unavailable or incomplete")
     return _DEFAULT_DIR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,14 +51,15 @@ _SENTINEL = _DEFAULT_DIR / "README.md"
 
 
 def _ensure_test_data() -> Path:
-    """Clone tests-data (minus ``con/``) if absent; skip data tests if unavailable.
+    """Clone tests-data if absent; skip data tests if it isn't available.
 
-    The tests-data repo (a fork of chemfiles/tests-data) ships EON fixtures under
-    ``con/``, but ``con`` is a reserved device name on Windows and git cannot
-    materialize it there. We read no ``con/`` data, so the checkout excludes it via
-    sparse-checkout on every platform — keeping the tree identical across OSes and
-    checkoutable on Windows. If tests-data still isn't available (e.g. offline),
-    skip the data-dependent tests via a sentinel rather than failing.
+    tests-data (a fork of chemfiles/tests-data) used to carry a ``con/`` directory
+    — a reserved device name Windows cannot check out, which aborted the whole
+    clone there. It has been removed upstream, so a plain clone now works on every
+    platform. (Sparse-checkout does NOT help: git rejects the reserved path during
+    checkout before sparse rules apply — keeping con/ out of the fork is the real
+    fix.) If tests-data still isn't available (e.g. offline), skip the
+    data-dependent tests via a ``README.md`` sentinel rather than failing.
 
     Deliberately does NOT ``git pull`` a present checkout: under ``-n auto`` the
     session fixture runs once per worker, so pulling would mutate the shared
@@ -68,30 +69,9 @@ def _ensure_test_data() -> Path:
     if not (_DEFAULT_DIR / ".git").exists():
         _DEFAULT_DIR.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--no-checkout",
-                _REPO_URL,
-                str(_DEFAULT_DIR),
-            ],
+            ["git", "clone", "--depth", "1", _REPO_URL, str(_DEFAULT_DIR)],
             cwd=_DEFAULT_DIR.parent,
         )
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(_DEFAULT_DIR),
-                "sparse-checkout",
-                "set",
-                "--no-cone",
-                "/*",
-                "!/con/",
-            ],
-        )
-        subprocess.run(["git", "-C", str(_DEFAULT_DIR), "checkout"])
     if not _SENTINEL.exists():
         pytest.skip("tests-data checkout unavailable or incomplete")
     return _DEFAULT_DIR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,15 +51,16 @@ _SENTINEL = _DEFAULT_DIR / "README.md"
 
 
 def _ensure_test_data() -> Path:
-    """Clone tests-data if absent; skip data tests if it isn't available.
+    """Clone tests-data (skipping ``con/``) if absent; skip data tests if absent.
 
-    tests-data (a fork of chemfiles/tests-data) used to carry a ``con/`` directory
-    — a reserved device name Windows cannot check out, which aborted the whole
-    clone there. It has been removed upstream, so a plain clone now works on every
-    platform. (Sparse-checkout does NOT help: git rejects the reserved path during
-    checkout before sparse rules apply — keeping con/ out of the fork is the real
-    fix.) If tests-data still isn't available (e.g. offline), skip the
-    data-dependent tests via a ``README.md`` sentinel rather than failing.
+    tests-data (a fork of chemfiles/tests-data) ships EON fixtures under ``con/``,
+    a reserved device name Windows cannot create — a plain clone aborts there. We
+    leave tests-data untouched and skip con/ at checkout instead. Two settings are
+    BOTH required on Windows: ``core.protectNTFS=false`` lets git process the con/
+    index entry without rejecting the name, and sparse-checkout keeps con/ off disk
+    so the OS is never asked to create it (nothing reads con/ data). If tests-data
+    still isn't available (e.g. offline), skip the data-dependent tests via a
+    ``README.md`` sentinel rather than failing.
 
     Deliberately does NOT ``git pull`` a present checkout: under ``-n auto`` the
     session fixture runs once per worker, so pulling would mutate the shared
@@ -69,9 +70,33 @@ def _ensure_test_data() -> Path:
     if not (_DEFAULT_DIR / ".git").exists():
         _DEFAULT_DIR.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            ["git", "clone", "--depth", "1", _REPO_URL, str(_DEFAULT_DIR)],
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--no-checkout",
+                _REPO_URL,
+                str(_DEFAULT_DIR),
+            ],
             cwd=_DEFAULT_DIR.parent,
         )
+        subprocess.run(
+            ["git", "-C", str(_DEFAULT_DIR), "config", "core.protectNTFS", "false"]
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(_DEFAULT_DIR),
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                "!/con/",
+            ],
+        )
+        subprocess.run(["git", "-C", str(_DEFAULT_DIR), "checkout"])
     if not _SENTINEL.exists():
         pytest.skip("tests-data checkout unavailable or incomplete")
     return _DEFAULT_DIR


### PR DESCRIPTION
## What

Keep `windows-latest` in the test matrix. Handle the `con/` problem by **excluding it at checkout** instead of dropping the platform.

`tests-data` (a fork of `chemfiles/tests-data`) ships EON fixtures under `con/`. `con` is a **reserved device name on Windows**, so git cannot materialize that directory — which aborted the whole working-tree checkout on Windows.

- **Fetch step + conftest**: clone `--no-checkout` then `git sparse-checkout set --no-cone '/*' '!/con/'` + `git checkout`, on **every** platform. We read no `con/` data anywhere, so dropping it keeps the tree identical across OSes and lets Windows check out the full data set minus con/.
- **Windows now runs the data tests** (previously they were skipped) — same coverage as Linux/macOS.
- Keeps the `README.md` sentinel skip as the offline fallback.

Supersedes the `--no-checkout` Windows special-case from #37, and replaces the (closed) #38 which wrongly dropped Windows.

## Paired change

`con/` is also being removed from the `MolCrafts/tests-data` fork; the sparse-checkout skip stays as durable protection in case an upstream `chemfiles` sync re-introduces it.

## Test plan

- [x] Verified locally: the clone sequence excludes `con/` and keeps all 36 other dirs + README
- [x] ruff format/check clean; YAML validates
- [ ] Windows CI runs the data suite (green)