### PR TITLE
release: v0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.0",
     "lark>=1.3.1",
-    "molcrafts-molrs==0.9.2",
+    "molcrafts-molrs==0.9.3",
     "molcrafts-mollog>=1.0.0",
     "molcrafts-molcfg>=1.2.0",
     "zarr>=3.0",

--- a/src/molpy/version.py
+++ b/src/molpy/version.py
@@ -9,7 +9,7 @@ molrs matches this version; it is called once on ``import molpy`` so a stale
 editable build or an out-of-date pin surfaces immediately.
 """
 
-version = "0.9.2"
+version = "0.9.3"
 release_date = "2026-07-23"
 
 


### PR DESCRIPTION
## Summary
- Joint version with molrs: **0.9.3**
- Pin `molcrafts-molrs==0.9.3` (exact match enforced by `check_molrs_version`)
- Ships master after the 0.9.2 product release + post-release CI/test-gate cleanup

## Test plan
- [x] local pre-commit / pre-push (lint + `pytest -m "not external"` in fresh venv)
- [ ] CI on this PR green before merge
- [ ] After merge: push `v0.9.3` tag → Release workflow → PyPI