### PR TITLE
ci: uv cache on default gate; Full matrix via uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           python-version: '3.12'
       - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
       - name: uv run --extra dev tox -e lint
         run: uv run --extra dev tox -e lint
 
@@ -30,5 +35,10 @@ jobs:
         with:
           python-version: '3.12'
       - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
       - name: uv run --extra dev tox -e py
         run: uv run --extra dev tox -e py

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,7 +1,7 @@
 name: Full
 
-# Multi-OS unit matrix (same tests as CI, broader platforms). No schedule —
-# runs on master push and on manual dispatch only.
+# Multi-OS unit matrix (same tests as default CI, broader platforms).
+# master push + workflow_dispatch only. tests-data is owned by tests/conftest.py.
 on:
   push:
     branches: [master]
@@ -20,15 +20,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-      - name: Fetch test data
-        shell: bash
-        run: |
-          dir=tests/tests-data
-          if [ -e "$dir/README.md" ]; then exit 0; fi
-          mkdir -p "$dir"
-          curl -fsSL https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz \
-            | tar -xz -C "$dir" --strip-components=1 --exclude='*/con' --exclude='*/con/*'
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Install package
+        run: uv pip install --system -e ".[dev]"
       - name: Unit tests
         run: pytest tests/ -m "not external" -n auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,17 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Install build tools
-        run: pip install build twine
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Extract version
         id: get_version
@@ -47,7 +46,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install package
-        run: pip install -e .
+        run: uv pip install --system -e .
 
       - name: Verify version match
         run: |
@@ -59,10 +58,7 @@ jobs:
           fi
 
       - name: Build package
-        run: python -m build
-
-      - name: Check package
-        run: twine check dist/*
+        run: uv pip install --system build && python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Default CI lint/test: `setup-uv` **enable-cache**
- Full matrix: `uv pip install` instead of cold `pip`; drop inline tests-data fetch (owned by `tests/conftest.py`)
- Release: uv for install/build

## Expected
- Default CI: faster dependency resolve on warm cache
- Full matrix: less cold pip churn on 6 OS×Python cells

## Test plan
- [x] Local tox-lint + tox-py green
- [ ] PR CI green