### PR TITLE
ci: run the default gate on every PR, not only master-targeted ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
   push:
     branches: [master, dev, dev-*]
     tags: ['v*']
+  # No `branches:` filter — every PR runs the gate regardless of its target.
+  # Integration lands on `dev`, so a `branches: [master]` filter left the
+  # actual integration path unguarded; an enumerated list is exactly the kind
+  # of thing that goes stale when a branch convention changes.
   pull_request:
-    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`ci.yml` had `pull_request: branches: [master]`, so a PR into any other branch triggered no CI at all.

### Accuracy note
An earlier version of this description claimed `dev` was the integration branch and therefore that the unguarded path was the one receiving day-to-day work. **The evidence contradicts that** and the claim is withdrawn: the last six merged PRs (#51–#56) all targeted `master`, so the real integration path has been gated all along. This is a latent hole, not an active one.

It is still worth closing. An enumerated branch list only stays correct while the branch convention does, and it fails *silently* — a PR into an unlisted branch reports no checks rather than a failure, which reads as "nothing to run" instead of "not gated". Dropping the filter makes the gate follow any future convention automatically.

Push triggers are unchanged.

### Separate finding, not addressed here
`dev` is **59 commits behind `master`** and carries 3 commits master never received:

    c21a5d6  fix(io): write LAMMPS forcefield coeffs in LAMMPS units
    6a2508a  refactor(io): sink LAMMPS forcefield write to molrs
    7888e33  refactor(io,ff): drop LAMMPS reader class and ForceField alias

Its last commit is 2026-07-29. Either that work should be salvaged onto master or the branch retired — leaving it looking like an integration branch invites someone to base work on a tree missing two releases.

Also: `full.yml` is `push: [master]` only, so the full suite never runs on a PR.

### Known follow-up
A PR from a `dev-*` branch now matches both `push` and `pull_request` and runs twice. The fix is a `concurrency` group, but neither molpy nor molrs uses one today, so that is a cross-repo convention decision rather than part of this change.

### Verification
`prek` hooks pass on the branch, including `CI lint (tox -e lint)`.