### PR TITLE
ci: stop re-running work master push already did

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,13 +4,17 @@ name: Bench
 # Frame) and tracks it over time via github-action-benchmark (pytest-benchmark
 # JSON). The suite measures molpy's thin Python facade over the molrs kernels.
 #
-# Kept off the per-PR path (benchmarks are slow + noisy on shared runners);
-# tracks perf on canonical pushes + on demand. The normal `pytest tests/` run
-# does not pick up benchmarks/.
+# Kept off the per-PR path (benchmarks are slow + noisy on shared runners).
+# Release-only cadence: at ~180s it was the largest single cost on every
+# master push, and per-commit benchmark points on shared runners are noisy
+# enough that the dashboard was tracking runner variance as much as molpy.
+# One point per release is a cleaner signal; run it by hand between releases
+# when a change is expected to move performance. The normal `pytest tests/`
+# run does not pick up benchmarks/.
 
 on:
   push:
-    branches: [master, main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -2,6 +2,10 @@ name: Full
 
 # Multi-OS unit matrix (same tests as CI, broader platforms). No schedule —
 # runs on master push and on manual dispatch only.
+#
+# ubuntu-latest is deliberately absent: ci.yml's `test` job already ran the
+# identical `pytest tests/ -m "not external" -n auto` on ubuntu for this same
+# push. This matrix exists to cover the platforms CI does not.
 on:
   push:
     branches: [master]
@@ -13,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
         python-version: ['3.14']
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The master-push path was ~463s across three workflows: CI 130s + Full 154s + Bench 179s. Two of those were paying for results they already had.

- **`full.yml` drops `ubuntu-latest`.** `ci.yml`'s `test` job runs the identical `pytest tests/ -m "not external" -n auto` on ubuntu for the same push, so the matrix spent 154s repeating it. It now covers only what CI does not: macOS and Windows.

- **`bench.yml` moves to `v*` tags + `workflow_dispatch`.** At ~180s it was the largest single per-push cost, and per-commit points on shared runners carry enough variance that the dashboard tracked runner noise alongside molpy. One point per release is a cleaner signal; dispatch by hand when a change is expected to move performance.

**The PR gate is untouched** — still ~130s, still exactly `tox -e lint` + `tox -e py`, the same two commands `prek` runs at pre-push. That alignment is the part worth keeping and this does not touch it.

Merging lint and test into one job was considered and rejected: they currently run in parallel, so wall-clock is `max(lint, test)`; merging would make it `lint + test`. Cheaper in runner-minutes, slower for the developer waiting on the PR.