### PR TITLE
fix(wrapper): Path-only internals for env/workdir (Windows CI)

### DIFF
--- a/.claude/notes/notes.md
+++ b/.claude/notes/notes.md
@@ -6,3 +6,14 @@ Evolving architectural decisions and project-level rules. Populated by `/mol:not
 
 **Promoted** → `.claude/notes/release.md` + CLAUDE.md § Release with molrs.
 Monorepo merge under molpy: **retracted**. Pin-parity scripts: **forbidden**.
+
+## pathlike-boundary-path-internal
+
+**Public / user-facing** path parameters accept `str | Path` (path-like).
+**At the boundary**, convert with `Path(...)` / `Path(...).expanduser()`.
+**Internal fields and logic use only `pathlib.Path`** — never keep bare `str`
+paths for filesystem locations after construction. Subprocess argv / env dicts
+are the only place to re-emit `str(path)`.
+
+Exceptions: symbolic names that are *not* paths (e.g. conda env name
+`"AmberTools25"`) stay `str`. Path-like conda prefixes are stored as `Path`.

--- a/src/molpy/pack/packer/packmol.py
+++ b/src/molpy/pack/packer/packmol.py
@@ -50,7 +50,8 @@ class Packmol(Packer):
         """
         Packer.__init__(self)
         self.executable = executable
-        self.workdir = workdir
+        # Public boundary accepts path-like; store Path only.
+        self.workdir = Path(workdir) if workdir is not None else None
 
     def __call__(
         self,

--- a/src/molpy/wrapper/base.py
+++ b/src/molpy/wrapper/base.py
@@ -27,10 +27,15 @@ class Wrapper(ABC):
 
     name: str
     exe: str
-    workdir: Path | None = None
+    workdir: str | Path | None = None
     env_vars: dict[str, str] = field(default_factory=dict)
     env: str | Path | None = None
     env_manager: str | None = None
+
+    def __post_init__(self) -> None:
+        # Public boundary accepts str | Path; internals always store Path.
+        if self.workdir is not None and not isinstance(self.workdir, Path):
+            self.workdir = Path(self.workdir)
 
     def process_env(self) -> EnvSpec:
         """Return the validated :class:`EnvSpec` for this wrapper."""

--- a/src/molpy/wrapper/env.py
+++ b/src/molpy/wrapper/env.py
@@ -11,6 +11,14 @@ Supported managers
   (or ``Scripts`` on Windows) into ``PATH``.  Covers standard venv,
   virtualenv, and uv-created environments (same layout).
 
+Path contract
+-------------
+Public entry points accept ``str | Path`` (path-like).  On resolve, any
+value that is a path (or looks like one) is converted to
+:class:`~pathlib.Path` and stored/used as ``Path`` only.  Conda *env
+names* (no path separators) remain plain ``str``.  Subprocess argv
+receives ``str(path)`` at the OS boundary only.
+
 This module is the single owner of env-isolation logic used by
 :class:`~molpy.wrapper.base.Wrapper` and higher-level facades that
 construct wrappers.
@@ -37,8 +45,16 @@ def _looks_like_path(value: str) -> bool:
         (os.sep in value)
         or ("/" in value)
         or ("\\" in value)
-        or value.startswith((".", "~", "/"))
+        or value.startswith((".", "~"))
+        or (len(value) >= 2 and value[1] == ":")  # Windows drive letter
     )
+
+
+def _as_path(value: str | Path) -> Path:
+    """Convert path-like input to :class:`Path` (expand ``~``)."""
+    if isinstance(value, Path):
+        return value.expanduser()
+    return Path(value).expanduser()
 
 
 def _bin_dir(prefix: Path) -> Path:
@@ -58,9 +74,11 @@ def _conda_exe() -> str:
 class EnvSpec:
     """Validated subprocess environment isolation.
 
-    Construct via :meth:`resolve` (or :meth:`system`).  Fields after
-    resolve are either both ``None`` (system) or a concrete manager kind
-    plus a non-``None`` ``env``.
+    Construct via :meth:`resolve` (or :meth:`system`).  After resolve:
+
+    * system — both fields ``None``
+    * conda name — ``env: str``, ``env_manager: "conda"``
+    * conda prefix / venv — ``env: Path``, ``env_manager: "conda"|"venv"``
     """
 
     env: str | Path | None = None
@@ -83,9 +101,10 @@ class EnvSpec:
 
         Both must be set together, or both omitted for the system
         environment.  Manager type is never inferred from ``env``.
+        Path-like values are stored as :class:`~pathlib.Path`.
 
         Args:
-            env: Conda env name / prefix, or venv prefix path.
+            env: Conda env name / prefix, or venv prefix (``str | Path``).
             env_manager: ``"conda"``, ``"venv"``, ``"pip"``, or
                 ``"virtualenv"``.
 
@@ -116,7 +135,15 @@ class EnvSpec:
                 f"Unsupported env_manager {env_manager!r}. "
                 f"Supported values: {_SUPPORTED}."
             )
-        return cls(env=env, env_manager=kind)
+
+        # venv always needs a filesystem prefix → Path
+        if kind == "venv":
+            return cls(env=_as_path(env), env_manager=kind)
+
+        # conda: Path / path-like str → Path prefix; bare name stays str
+        if isinstance(env, Path) or _looks_like_path(str(env)):
+            return cls(env=_as_path(env), env_manager=kind)
+        return cls(env=str(env), env_manager=kind)
 
     # -- queries ------------------------------------------------------------
 
@@ -125,6 +152,16 @@ class EnvSpec:
         """True when no isolation is configured."""
         return self.env_manager is None
 
+    def _prefix_path(self) -> Path:
+        """Filesystem prefix for venv / conda -p (must be a :class:`Path`)."""
+        assert self.env is not None
+        if not isinstance(self.env, Path):
+            raise TypeError(
+                f"EnvSpec.env must be Path for manager {self.env_manager!r}, "
+                f"got {type(self.env).__name__}: {self.env!r}"
+            )
+        return self.env
+
     # -- subprocess helpers -------------------------------------------------
 
     def command_prefix(self, *, no_capture_output: bool = False) -> list[str]:
@@ -132,6 +169,7 @@ class EnvSpec:
 
         For conda this is ``[conda, run, (-n|-p), <env>]``.  For venv /
         system the prefix is empty (isolation is via :meth:`merge_environ`).
+        Path prefixes are emitted as ``str(path)`` for the OS.
 
         Args:
             no_capture_output: When True, insert
@@ -149,11 +187,7 @@ class EnvSpec:
 
         if isinstance(self.env, Path):
             return [*prefix, "-p", str(self.env)]
-
-        env_str = str(self.env)
-        if _looks_like_path(env_str):
-            return [*prefix, "-p", env_str]
-        return [*prefix, "-n", env_str]
+        return [*prefix, "-n", self.env]
 
     def merge_environ(
         self,
@@ -169,8 +203,7 @@ class EnvSpec:
         merged = dict(base if base is not None else os.environ)
 
         if self.env_manager == "venv":
-            assert self.env is not None
-            prefix = self.env if isinstance(self.env, Path) else Path(str(self.env))
+            prefix = self._prefix_path()
             bin_dir = _bin_dir(prefix)
             existing = merged.get("PATH", "")
             merged["PATH"] = str(bin_dir) + (os.pathsep + existing if existing else "")
@@ -180,35 +213,39 @@ class EnvSpec:
             merged.update(extra)
         return merged
 
-    def resolve_executable(self, exe: str) -> str | None:
+    def resolve_executable(self, exe: str | Path) -> str | None:
         """Best-effort absolute path for *exe* inside this environment.
 
-        Returns ``None`` if the executable cannot be found.
+        *exe* may be path-like at the public boundary; filesystem paths are
+        converted to :class:`~pathlib.Path` immediately.  Returns a ``str``
+        suitable for subprocess argv, or ``None`` if not found.
         """
-        exe_path = Path(exe)
-        if exe_path.is_file():
-            return str(exe_path)
+        # Explicit path (Path object or path-like string) — no PATH search.
+        if isinstance(exe, Path) or (isinstance(exe, str) and _looks_like_path(exe)):
+            exe_path = _as_path(exe)
+            return str(exe_path.resolve()) if exe_path.is_file() else None
+
+        name = str(exe)
 
         if self.is_system:
-            return shutil.which(exe)
+            return shutil.which(name)
 
         if self.env_manager == "venv":
-            assert self.env is not None
-            prefix = self.env if isinstance(self.env, Path) else Path(str(self.env))
+            prefix = self._prefix_path()
             bin_dir = _bin_dir(prefix)
-            candidates = [bin_dir / exe]
-            if os.name == "nt" and not exe.lower().endswith(".exe"):
-                candidates.append(bin_dir / f"{exe}.exe")
+            candidates = [bin_dir / name]
+            if os.name == "nt" and not name.lower().endswith(".exe"):
+                candidates.append(bin_dir / f"{name}.exe")
             for candidate in candidates:
                 if candidate.is_file():
-                    return str(candidate)
-            return shutil.which(exe, path=self.merge_environ().get("PATH"))
+                    return str(candidate.resolve())
+            return shutil.which(name, path=self.merge_environ().get("PATH"))
 
         # conda: ask the env via ``conda run … which``
         cmd_prefix = self.command_prefix()
         try:
             proc = subprocess.run(
-                [*cmd_prefix, "which", exe],
+                [*cmd_prefix, "which", name],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/tests/test_wrapper/test_env.py
+++ b/tests/test_wrapper/test_env.py
@@ -28,18 +28,25 @@ class TestEnvSpecResolve:
     def test_conda_name(self):
         spec = EnvSpec.resolve("AmberTools25", "conda")
         assert spec.env == "AmberTools25"
+        assert isinstance(spec.env, str)
         assert spec.env_manager == "conda"
         assert not spec.is_system
 
-    def test_conda_prefix_path(self):
+    def test_conda_prefix_str_becomes_path(self):
         spec = EnvSpec.resolve("/opt/conda/envs/at", "conda")
         assert spec.env_manager == "conda"
-        assert spec.command_prefix()[1:4] == ["run", "-p", "/opt/conda/envs/at"]
+        assert isinstance(spec.env, Path)
+        assert spec.env == Path("/opt/conda/envs/at")
+        prefix = spec.command_prefix()
+        assert prefix[1:3] == ["run", "-p"]
+        assert Path(prefix[3]) == Path("/opt/conda/envs/at")
 
-    def test_venv_aliases_normalise(self):
+    def test_venv_aliases_normalise_to_path(self):
         for alias in ("venv", "pip", "virtualenv", "Venv", "PIP"):
             spec = EnvSpec.resolve("/path/to/.venv", alias)
             assert spec.env_manager == "venv"
+            assert isinstance(spec.env, Path)
+            assert spec.env == Path("/path/to/.venv")
 
     def test_unsupported_manager(self):
         with pytest.raises(ValueError, match="Unsupported env_manager"):
@@ -56,8 +63,12 @@ class TestEnvSpecCommandPrefix:
         assert prefix[1:4] == ["run", "-n", "AmberTools25"]
 
     def test_conda_path_object_uses_p(self):
-        prefix = EnvSpec.resolve(Path("/opt/envs/at"), "conda").command_prefix()
-        assert prefix[1:4] == ["run", "-p", "/opt/envs/at"]
+        env_path = Path("/opt/envs/at")
+        prefix = EnvSpec.resolve(env_path, "conda").command_prefix()
+        assert prefix[1:3] == ["run", "-p"]
+        # Internal storage is Path; argv boundary is str(path) (OS-native).
+        assert Path(prefix[3]) == env_path
+        assert prefix[3] == str(env_path)
 
     def test_no_capture_output_flag(self):
         prefix = EnvSpec.resolve("e", "conda").command_prefix(no_capture_output=True)
@@ -69,11 +80,19 @@ class TestEnvSpecMergeEnviron:
     def test_venv_injects_path_and_virtual_env(self, tmp_path: Path):
         venv = tmp_path / "venv"
         spec = EnvSpec.resolve(venv, "venv")
+        assert isinstance(spec.env, Path)
         merged = spec.merge_environ(base={"PATH": "/usr/bin", "HOME": "/home"})
         bin_dir = venv / ("Scripts" if os.name == "nt" else "bin")
         assert merged["PATH"].split(os.pathsep)[0] == str(bin_dir)
         assert merged["VIRTUAL_ENV"] == str(venv)
+        assert Path(merged["VIRTUAL_ENV"]) == venv
         assert merged["HOME"] == "/home"
+
+    def test_venv_str_input_becomes_path(self, tmp_path: Path):
+        venv = tmp_path / "venv"
+        spec = EnvSpec.resolve(str(venv), "venv")
+        assert isinstance(spec.env, Path)
+        assert spec.env == venv
 
     def test_extra_overrides(self):
         merged = EnvSpec.system().merge_environ(
@@ -93,7 +112,8 @@ class TestEnvSpecResolveExecutable:
         exe = tmp_path / "tool"
         exe.write_text("#!/bin/sh\n")
         exe.chmod(0o755)
-        assert EnvSpec.system().resolve_executable(str(exe)) == str(exe)
+        assert EnvSpec.system().resolve_executable(str(exe)) == str(exe.resolve())
+        assert EnvSpec.system().resolve_executable(exe) == str(exe.resolve())
 
     def test_venv_bin_lookup(self, tmp_path: Path):
         bin_dir = tmp_path / ("Scripts" if os.name == "nt" else "bin")
@@ -102,7 +122,7 @@ class TestEnvSpecResolveExecutable:
         tool.write_text("#!/bin/sh\n")
         tool.chmod(0o755)
         found = EnvSpec.resolve(tmp_path, "venv").resolve_executable("antechamber")
-        assert found == str(tool)
+        assert found == str(tool.resolve())
 
     def test_system_which(self):
         # `echo` is on PATH in all reasonable environments used for tests.


### PR DESCRIPTION
## Summary
- Full CI (Windows) failed: `Path(\"/opt/envs/at\")` → `\\\\opt\\\\envs\\\\at` on win32 while tests asserted Unix strings
- Rule: user-facing `str | Path`; at boundary convert to `Path`; internals use `Path` only
- EnvSpec stores path prefixes as `Path`; conda names stay `str`
- Wrapper.workdir and Packmol.workdir normalized to `Path`

## Test plan
- [x] `pytest tests/test_wrapper tests/test_engine/test_base.py tests/test_builder/test_ambertools.py`
- [ ] Full CI including windows-latest