### PR TITLE
ci: 3 OS × Python 3.12/3.13/3.14 matrix (no skipped minors)

### DIFF
--- a/.claude/notes/ci.md
+++ b/.claude/notes/ci.md
@@ -72,6 +72,12 @@ Do **not** `SKIP=molrs-pin-on-pypi` to land features that need unpublished molrs
 
 ## CI matrix convention
 
-Test job runs on ubuntu + macos × Python 3.12/3.13 with
-`pytest tests/ -v -m "not external" --cov=src/molpy`; coverage upload only from
-ubuntu / 3.12.
+**Do not skip a minor** of `requires-python` (`>=3.12` → **3.12, 3.13, 3.14**).
+
+| Workflow | Matrix |
+|---|---|
+| `ci.yml` `test` | **3 OS** (`ubuntu` / `macos` / `windows`) × **3.12 / 3.13 / 3.14** |
+| `full.yml` `test` | same 3×3 on master push |
+| `release.yml` | same 3×3 **before** PyPI publish |
+
+Lint stays single-job on ubuntu + 3.14. Never drop 3.13 “because ends only”.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,12 @@
 name: CI
 
-# Default gate: same as prek — tox -e lint + tox -e py.
+# Default gate: lint once + unit matrix over 3 OS × Python 3.12 / 3.13 / 3.14.
 # Unit suite only: mocks for wrappers/engines; no third-party binaries.
 on:
   push:
     branches: [master, dev, dev-*]
     tags: ['v*']
   # No `branches:` filter — every PR runs the gate regardless of its target.
-  # Integration lands on `dev`, so a `branches: [master]` filter left the
-  # actual integration path unguarded; an enumerated list is exactly the kind
-  # of thing that goes stale when a branch convention changes.
   pull_request:
   workflow_dispatch:
 
@@ -26,12 +23,26 @@ jobs:
         run: uv run --extra dev tox -e lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.14'
+          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v9.0.0
+      - name: Fetch test data
+        shell: bash
+        run: |
+          dir=tests/tests-data
+          if [ -e "$dir/README.md" ]; then exit 0; fi
+          mkdir -p "$dir"
+          curl -fsSL https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz \
+            | tar -xz -C "$dir" --strip-components=1 --exclude='*/con' --exclude='*/con/*'
       - name: uv run --extra dev tox -e py
+        # tox uses the runner's Python (matrix.python-version) as base.
         run: uv run --extra dev tox -e py

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,11 +1,8 @@
 name: Full
 
-# Multi-OS unit matrix (same tests as CI, broader platforms). No schedule —
-# runs on master push and on manual dispatch only.
-#
-# ubuntu-latest is deliberately absent: ci.yml's `test` job already ran the
-# identical `pytest tests/ -m "not external" -n auto` on ubuntu for this same
-# push. This matrix exists to cover the platforms CI does not.
+# Same 3 OS × 3.12 / 3.13 / 3.14 unit matrix as CI, on master push and
+# manual dispatch. Kept as an explicit multi-platform smoke after land so
+# master always re-runs the full grid even when CI was skipped or rebased.
 on:
   push:
     branches: [master]
@@ -17,10 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu covered by ci.yml default gate; Full only multi-OS.
-        os: [macos-latest, windows-latest]
-        # Both ends of the supported range.
-        python-version: ['3.12', '3.14']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 # Tag push on MolCrafts/molpy → pure-Python wheel to PyPI (trusted publishing).
 # Requires molcrafts-molrs on the same major.minor already on PyPI (see release notes).
+#
+# Before publish: run the same 3 OS × 3.12 / 3.13 / 3.14 unit matrix as CI
+# (do not skip a minor of the supported range).
 on:
   push:
     tags: ["v*"]
@@ -12,7 +15,34 @@ permissions:
   id-token: write
 
 jobs:
+  test:
+    if: github.repository == 'MolCrafts/molpy'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Fetch test data
+        shell: bash
+        run: |
+          dir=tests/tests-data
+          if [ -e "$dir/README.md" ]; then exit 0; fi
+          mkdir -p "$dir"
+          curl -fsSL https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz \
+            | tar -xz -C "$dir" --strip-components=1 --exclude='*/con' --exclude='*/con/*'
+      - name: Unit tests
+        run: pytest tests/ -n auto
+
   release:
+    needs: test
     if: github.repository == 'MolCrafts/molpy'
     runs-on: ubuntu-latest
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,8 @@ commands = [
 [tool.tox.env.py]
 package = "wheel"
 extras = ["dev"]
-base_python = ["python3.14"]
+# Follow the runner interpreter so CI matrix 3.12/3.13/3.14 all exercise tox -e py.
+base_python = ["python3"]
 pass_env = ["HOME", "PATH", "SSH_AUTH_SOCK", "TERM"]
 commands_pre = [
     [


### PR DESCRIPTION
Expand CI/Full/Release test grids to all supported platforms and CPython minors. Do not skip 3.13.