### PR TITLE
release: v0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 # No lark / zarr / RDKit / etc. as hard deps — those live in molrs or optional extras.
 dependencies = [
     "numpy>=2.0",
-    "molcrafts-molrs>=0.12.0,<0.13",
+    "molcrafts-molrs>=0.13.0,<0.14",
     "molcrafts-mollog>=1.0.0",
     "molcrafts-molcfg>=1.2.0",
 ]

--- a/src/molpy/io/data/lammps.py
+++ b/src/molpy/io/data/lammps.py
@@ -64,7 +64,7 @@ class LammpsDataResult:
 
 
 class LammpsDataReader(DataReader[LammpsDataResult]):
-    """Modern LAMMPS data file reader using Block.from_csv."""
+    """Reader for LAMMPS data files."""
 
     def __init__(self, path: str | Path, atom_style: str = "full") -> None:
         super().__init__(Path(path))

--- a/src/molpy/version.py
+++ b/src/molpy/version.py
@@ -10,7 +10,7 @@ It is called once on ``import molpy`` so a stale major/minor pin surfaces
 immediately.
 """
 
-version = "0.12.3"
+version = "0.13.0"
 release_date = "2026-08-07"
 
 

--- a/tests/test_core/test_frame.py
+++ b/tests/test_core/test_frame.py
@@ -36,7 +36,7 @@ class TestBlock:
         for k in ("a", "b"):
             assert np.array_equal(blk[k], restored[k])
 
-    def test_block_from_csv_file(self, tmp_path):
+    def test_read_block_csv_file(self, tmp_path):
         """Test read_block_csv with file path."""
         csv_content = """x,y,z,atom_type
 0.0,0.0,0.0,C
@@ -61,7 +61,7 @@ class TestBlock:
         # Test string column
         assert np.array_equal(block["atom_type"], np.array(["C", "O", "N"]))
 
-    def test_block_from_csv_stringio(self):
+    def test_read_block_csv_stringio(self):
         """Test read_block_csv with StringIO."""
         csv_content = """name,age,height
 Alice,25,1.65
@@ -81,7 +81,7 @@ Charlie,35,1.75"""
         assert np.array_equal(block["age"], np.array([25.0, 30.0, 35.0]))
         assert np.array_equal(block["height"], np.array([1.65, 1.80, 1.75]))
 
-    def test_block_from_csv_delimiter(self):
+    def test_read_block_csv_delimiter(self):
         """Test read_block_csv with custom delimiter."""
         csv_content = """x;y;z;atom_type
 0.0;0.0;0.0;C
@@ -94,13 +94,13 @@ Charlie,35,1.75"""
         assert block.nrows == 2
         assert np.array_equal(block["x"], np.array([0.0, 1.0]))
 
-    def test_block_from_csv_empty_file(self):
+    def test_read_block_csv_empty_file(self):
         """Test read_block_csv with empty file."""
         csv_io = StringIO("")
         with pytest.raises(ValueError, match="empty"):
             read_block_csv(csv_io)
 
-    def test_block_from_csv_no_header(self):
+    def test_read_block_csv_no_header(self):
         """Test read_block_csv with no header CSV."""
         csv_content = """0.0,0.0,0.0,C
 1.0,1.0,1.0,O
@@ -120,7 +120,7 @@ Charlie,35,1.75"""
         assert np.array_equal(block["z"], np.array([0.0, 1.0, 2.0]))
         assert np.array_equal(block["atom_type"], np.array(["C", "O", "N"]))
 
-    def test_block_from_csv_no_header_file(self, tmp_path):
+    def test_read_block_csv_no_header_file(self, tmp_path):
         """Test read_block_csv with no header CSV file."""
         csv_content = """0.0,0.0,0.0
 1.0,1.0,1.0
@@ -137,7 +137,7 @@ Charlie,35,1.75"""
         assert np.array_equal(block["y"], np.array([0.0, 1.0, 2.0]))
         assert np.array_equal(block["z"], np.array([0.0, 1.0, 2.0]))
 
-    def test_block_from_csv_header_mismatch(self):
+    def test_read_block_csv_header_mismatch(self):
         """Test read_block_csv with header length mismatch."""
         csv_content = """0.0,0.0,0.0
 1.0,1.0,1.0"""
@@ -153,7 +153,7 @@ Charlie,35,1.75"""
         assert set(block.keys()) == {"x", "y"}
         assert block.nrows == 2
 
-    def test_block_from_csv_type_inference(self):
+    def test_read_block_csv_type_inference(self):
         """Test read_block_csv with automatic type inference."""
         csv_content = """id,name,age,height,active
 1,Alice,25,1.65,True
@@ -180,7 +180,7 @@ Charlie,35,1.75"""
         assert np.array_equal(block["height"], np.array([1.65, 1.80, 1.75]))
         assert np.array_equal(block["active"], np.array(["True", "False", "True"]))
 
-    def test_block_from_csv_mixed_types_no_header(self):
+    def test_read_block_csv_mixed_types_no_header(self):
         """Test read_block_csv with mixed types and no header."""
         csv_content = """1,Alice,25.5,True
 2,Bob,30.0,False

--- a/tests/test_io/test_data/test_lammps_data.py
+++ b/tests/test_io/test_data/test_lammps_data.py
@@ -1,8 +1,8 @@
 """
 Tests for LammpsDataReader and LammpsDataWriter classes.
 
-This module tests the modern LAMMPS data file I/O using Block.from_csv
-with space delimiter and mp.ForceField for force field parameters.
+Covers the space-delimited data file and the mp.ForceField parameters
+that come with it.
 """
 
 import os


### PR DESCRIPTION
Tracks molrs 0.13.0, where serialization moved into `molrs.io`.

Nothing in molpy called the constructors that moved, so the pin and the version are the whole change, alongside the docstrings and test names that still described the old spelling.

1679 passed against molcrafts-molrs 0.13.0.