### PR TITLE
release: v0.13.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 # No lark / zarr / RDKit / etc. as hard deps — those live in molrs or optional extras.
 dependencies = [
     "numpy>=2.0",
-    "molcrafts-molrs>=0.13.1,<0.14",
+    "molcrafts-molrs>=0.13.2,<0.14",
     "molcrafts-mollog>=1.0.0",
     "molcrafts-molcfg>=1.2.0",
 ]

--- a/src/molpy/version.py
+++ b/src/molpy/version.py
@@ -10,8 +10,8 @@ It is called once on ``import molpy`` so a stale major/minor pin surfaces
 immediately.
 """
 
-version = "0.13.1"
-release_date = "2026-08-13"
+version = "0.13.2"
+release_date = "2026-08-19"
 
 
 def _minor_tuple(ver: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- Pair with molrs 0.13.2 (DCD/XTC/TRR streaming).
- Pin `molcrafts-molrs>=0.13.2,<0.14`. Same 0.13 minor (check_molrs_version).

## Test plan
- [x] tox -e lint
- [ ] CI