### PR TITLE
chore: ignore local MD benchmark scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ a.out
 chemfile-testcases/
 examples/data/
 
+# Local MD driver scratch (Kokkos builds, slurm logs, npz traces)
+benchmarks/md/
+
 # C extensions
 *.so
 


### PR DESCRIPTION
Ignore `benchmarks/md/` (Kokkos builds, slurm logs, npz traces). Local-only scratch.