### PR TITLE
ci: molrs 0.14 from git; nightly depends on molrs-nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,6 @@ jobs:
           mkdir -p "$dir"
           curl -fsSL https://github.com/molcrafts/tests-data/archive/refs/heads/master.tar.gz \
             | tar -xz -C "$dir" --strip-components=1 --exclude='*/con' --exclude='*/con/*'
-      - run: uv run --extra dev tox -e py
+      # tox's pip install does not honor [tool.uv.sources]; uv does, so the
+      # unpublished molrs 0.14 git pin actually resolves here.
+      - run: uv run --extra dev python -m pytest tests/ -n auto

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,13 +69,27 @@ jobs:
           t = re.sub(r'^version\s*=\s*".*?"', f'version = "{dev}"', t, count=1, flags=re.M)
           p.write_text(t)
           PY
-          # Rename the PyPI distribution to the nightly project.
+          # Rename the PyPI distribution to the nightly project and bind the
+          # molrs pin to the matching nightly package (stable 0.14 is not on
+          # PyPI yet; `tool.uv.sources` is uv-only and would not help pip).
           python - <<'PY'
           import re, pathlib
           p = pathlib.Path("pyproject.toml")
           t = p.read_text()
           t = re.sub(r'^name\s*=\s*"molcrafts-molpy"',
                      'name = "molcrafts-molpy-nightly"', t, count=1, flags=re.M)
+          t = re.sub(
+              r'"molcrafts-molrs>=0\.14\.0,<0\.15"',
+              '"molcrafts-molrs-nightly>=0.14.0.dev0"',
+              t,
+              count=1,
+          )
+          t = re.sub(
+              r'\n# Until molcrafts-molrs 0\.14 is on PyPI[\s\S]*?rev = "dev" \}\n',
+              '\n',
+              t,
+              count=1,
+          )
           p.write_text(t)
           PY
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,11 @@ filterwarnings = [
     "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 
+# Until molcrafts-molrs 0.14 is on PyPI, uv (CI + local) installs the 0.14
+# line from git. The published PyPI pin in [project] dependencies is unchanged.
+[tool.uv.sources]
+molcrafts-molrs = { git = "https://github.com/MolCrafts/molrs.git", subdirectory = "molrs-python", rev = "dev" }
+
 [tool.tox]
 requires = ["tox>=4.23"]
 env_list = ["lint", "py"]


### PR DESCRIPTION
## Why
`dev` CI is red: `uv` cannot satisfy `molcrafts-molrs>=0.14.0,<0.15` because PyPI only has 0.13.2.

The local pre-push hook `molrs-pin-on-pypi` is the same constraint. This PR does **not** change the published pin; it only teaches uv/CI to install molrs 0.14 from git until a tagged molrs 0.14 exists.

## What
- `[tool.uv.sources]` → `MolCrafts/molrs@dev` / `molrs-python` (uv/CI only).
- Nightly job rewrites the runtime pin to `molcrafts-molrs-nightly>=0.14.0.dev0`.

Needed before cutting a molpy nightly on the 0.14 line.