### PR TITLE
ci: pre-push pytest via uv (match CI); don't --no-verify for unpublished molrs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 # prek: pre-commit = lint; pre-push = molrs pin + tests
-# CI: lint job + 3 OS × 3.12–3.14 matrix (ci.yml)
+# CI: lint job + 3 OS × 3.12–3.14 matrix (ci.yml).
+# Tests MUST use `uv run pytest`, not tox: tox's pip ignores [tool.uv.sources].
 
 default_install_hook_types: [pre-commit, pre-push]
+default_stages: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -36,9 +38,10 @@ repos:
         always_run: true
         stages: [pre-push]
 
-      - id: tox-py
-        name: tox -e py
-        entry: uv run --extra dev tox -e py
+      # Same command as ci.yml `test` — uv honors [tool.uv.sources], tox/pip does not.
+      - id: pytest
+        name: uv pytest (CI parity)
+        entry: uv run --extra dev python -m pytest tests/ -n auto
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit/check_molrs_pin_on_pypi.py
+++ b/.pre-commit/check_molrs_pin_on_pypi.py
@@ -41,6 +41,21 @@ def _is_next_minor(lo: tuple[int, int], hi: tuple[int, int]) -> bool:
     return hi == (lo[0], lo[1] + 1) or hi == (lo[0] + 1, 0)
 
 
+def _has_uv_source_override(text: str) -> bool:
+    """True when [tool.uv.sources] redirects molcrafts-molrs off PyPI."""
+    in_sources = False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line.startswith("["):
+            in_sources = line.strip() == "[tool.uv.sources]"
+            continue
+        if in_sources and line.strip().startswith("molcrafts-molrs"):
+            return any(tok in line for tok in ("git", "path", "url"))
+    return False
+
+
 def _parse_pin(text: str) -> tuple[str, tuple[int, int] | None, str | None]:
     """Return (kind, minor|None, exact_version|None).
 
@@ -87,6 +102,17 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Git/path override is how unpublished molrs 0.14 is resolved (CI + local
+    # `uv run`). Blocking the push for a missing PyPI release forces
+    # `--no-verify`, which also skips pytest. The PyPI pin still has to be
+    # well-formed; we just skip the network check.
+    if _has_uv_source_override(text):
+        print(
+            "ok: [tool.uv.sources] overrides molcrafts-molrs "
+            "(uv/CI git pin; PyPI publish not required to push)"
+        )
+        return 0
 
     try:
         if kind == "exact":


### PR DESCRIPTION
## Why
CI runs `uv run pytest` because tox/pip ignores `[tool.uv.sources]`. Pre-push still ran `tox -e py`, so a green local push could be a red CI — and the molrs-on-PyPI hook then forced `--no-verify`, which skipped pytest entirely.

## Change
- Pre-push test command = CI test command (`uv run --extra dev python -m pytest tests/ -n auto`).
- If `[tool.uv.sources]` git/path-overrides molrs, skip the PyPI existence check (pin format still validated).
- `default_stages: [pre-commit, pre-push]` so a `--no-verify` commit still hits the fast gates on push.